### PR TITLE
Fix setup

### DIFF
--- a/setup_local_env.sh
+++ b/setup_local_env.sh
@@ -48,7 +48,7 @@ fi
 
 # Install Wizard in development mode
 echo "Installing Wizard in development mode..."
-uv tool install -e "${REPO_ROOT}/src/wizard"
+uv tool install --python 3.12 -e "${REPO_ROOT}/src/wizard"
 
 # Ensure Hugging Face token is available (needed to download files)
 if [[ -z "${HF_TOKEN}" ]]; then

--- a/src/wizard/alpasim_wizard/scenes/sceneset.py
+++ b/src/wizard/alpasim_wizard/scenes/sceneset.py
@@ -146,11 +146,18 @@ class USDZManager:
 
     sim_scenes: pl.DataFrame
     sim_suites: pl.DataFrame
-    s3: S3Connection
     cache_dir: str
+    _s3: S3Connection | None = None
 
     ALL_USDZ_DIR_NAME: ClassVar[str] = "all-usdzs"
     SCENESETS_DIR_NAME: ClassVar[str] = "scenesets"
+
+    @property
+    def s3(self) -> S3Connection:
+        """Lazily create S3 connection only when needed for Swiftstack downloads."""
+        if self._s3 is None:
+            self._s3 = S3Connection.from_env_vars()
+        return self._s3
 
     @property
     def scenesets_dir(self) -> str:
@@ -185,7 +192,6 @@ class USDZManager:
         manager = cls(
             sim_scenes=sim_scenes,
             sim_suites=sim_suites,
-            s3=S3Connection.from_env_vars(),
             cache_dir=cache_dir,
         )
 

--- a/src/wizard/pyproject.toml
+++ b/src/wizard/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "alpasim_wizard"
 version = "0.0.1"
-requires-python = ">=3.11.0"
+requires-python = ">=3.11.0,<3.13.0"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",


### PR DESCRIPTION
* Add python 3.12 constraint to `alpasim_wizard` as hydra is incompatible with 3.14. Curiously, `uv tool` ignores the upper bound in `pyproject.yaml`
* Lazyily init s3 as it's not needed for huggingface (but results in an error due to the missing `ALPAMAYO_S3_SECRET`) 