### PR TITLE
Fix grpc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,8 @@ members = [
 override-dependencies = [
    "flash-attn; python_version < '0'",
 ]
+constraint-dependencies = [
+  # setuptools 82+ removed pkg_resources, which grpcio-tools 1.62.3 still needs.
+  # Remove this constraint when grpcio-tools and protobuf are upgraded to 5.x+.
+  "setuptools<82",
+]

--- a/src/grpc/pyproject.toml
+++ b/src/grpc/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = [ "setuptools>=61.0", "grpcio-tools", "protobuf>=4.0.0" ]
+requires = [ "setuptools>=61.0,<82", "grpcio-tools", "protobuf>=4.0.0" ]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Temporary fix: Need to pin `setuptools` until we upgrade to protobuf 5+