### PR TITLE
wizard: add docker compose build step to generated run.sh

### DIFF
--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -410,6 +410,7 @@ the context of a full simulation.
 1. (Terminal 1) Start the rest of the simulation with docker compose:
 
    ```bash
+   docker compose -f docker-compose.yaml build
    docker compose -f docker-compose.yaml --profile sim up runtime-0 driver-0 physics-0 sensorsim-0
    ```
 

--- a/src/wizard/alpasim_wizard/deployment/docker_compose.py
+++ b/src/wizard/alpasim_wizard/deployment/docker_compose.py
@@ -35,6 +35,7 @@ class DockerComposeDeployment:
 
         Note: This does not actually start the service. This can be done using
         ```bash
+        docker compose build
         docker compose --profile sim up
         docker compose --profile eval up
         docker compose --profile aggregation up
@@ -80,6 +81,16 @@ class DockerComposeDeployment:
             "set -e",
             "",
         ]
+
+        # Build local images if needed
+        script_lines.extend(
+            [
+                "# Build local images if needed",
+                'echo "Building local images..."',
+                f"docker compose -f {docker_compose_filepath} build",
+                "",
+            ]
+        )
 
         # Always run simulation phase (required)
         script_lines.extend(


### PR DESCRIPTION
## Summary
- Local OSS deployments (e.g. `+deploy=local_oss_2gpus`) fail because `alpasim-base` is a locally-built image that cannot be pulled from a registry
- The generated `run.sh` now runs `docker compose build` before `docker compose up` to ensure local images are built before starting services

## Changes
- `src/wizard/alpasim_wizard/deployment/docker_compose.py` — added a `docker compose build` step in `generate_run_script()` before the simulation phase

## Test plan
- [x] Verified locally: generated `run.sh` includes the build step
- [x] Docker correctly builds images from cache when `run.sh` is executed