### PR TITLE
Netrc Files Optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 This document lists major updates which change UX and require adaptation.
 It should be sorted by date (more recent on top) and link to MRs which introduce the changes.
 
+## Make ~/.netrc optional for public users (17.03.26)
+References to `~/.netrc` in the Dockerfile and wizard's Docker Compose generation were unconditional, requiring all users to have the file. The Dockerfile now conditionally sets `NETRC` only when the secret is provided, and the wizard only includes the `netrc` secret in the compose config when `~/.netrc` exists on the host.
+
 ## Composable dependency management (12.03.26)
 The root `pyproject.toml` now exposes every workspace member as a named optional-dependency extra, enabling composable installs from the repo root. A bare `uv sync` installs nothing (avoiding heavy deps like torch by default).
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 # Build command (run from repo root):
+#   docker build -t alpasim-base .
+#
+# For private dependencies (requires ~/.netrc with credentials):
 #   docker build --secret id=netrc,src=$HOME/.netrc -t alpasim-base .
 #
 # Automatically detects architecture:
@@ -32,14 +35,14 @@ ENV UV_LINK_MODE=copy
 WORKDIR /repo/src/grpc
 RUN --mount=type=secret,id=netrc,target=/root/.netrc \
     --mount=type=cache,target=/root/.cache/uv \
-    NETRC=/root/.netrc uv sync
+    sh -c 'if [ -f /root/.netrc ]; then export NETRC=/root/.netrc; fi && uv sync'
 RUN uv run compile-protos --no-sync
 
 WORKDIR /repo
 
 RUN --mount=type=secret,id=netrc,target=/root/.netrc \
     --mount=type=cache,target=/root/.cache/uv \
-    NETRC=/root/.netrc uv sync --extra all
+    sh -c 'if [ -f /root/.netrc ]; then export NETRC=/root/.netrc; fi && uv sync --extra all'
 
 ENV UV_CACHE_DIR=/tmp/uv-cache
 ENV UV_NO_SYNC=1

--- a/src/wizard/alpasim_wizard/deployment/docker_compose.py
+++ b/src/wizard/alpasim_wizard/deployment/docker_compose.py
@@ -92,12 +92,14 @@ class DockerComposeDeployment:
         repo_root = str(find_repo_root(__file__))
 
         if not container.service_config.external_image:
-            ret["build"] = {
+            build_config: dict[str, Any] = {
                 "context": repo_root,
                 "dockerfile": "Dockerfile",
                 "tags": [container.service_config.image],
-                "secrets": ["netrc"],
             }
+            if Path.home().joinpath(".netrc").exists():
+                build_config["secrets"] = ["netrc"]
+            ret["build"] = build_config
 
         if container.command:
             ret["entrypoint"] = "bash"
@@ -186,11 +188,12 @@ class DockerComposeDeployment:
             services[c.uuid] = service
 
         # Create compose structure with ordered services
-        compose = {
+        compose: dict[str, Any] = {
             "networks": {"microservices_network": {"driver": "bridge"}},
-            "secrets": {"netrc": {"file": "${HOME}/.netrc"}},
             "services": services,  # Services maintain insertion order in Python 3.7+
         }
+        if Path.home().joinpath(".netrc").exists():
+            compose["secrets"] = {"netrc": {"file": "${HOME}/.netrc"}}
 
         # Write to file
         filename = "docker-compose.yaml"


### PR DESCRIPTION
**Issue:**

Recent changes made it necessary for users to have a ~/.netrc file to properly run Alpasim. This was unintended.

**Root Cause:**

References to the .netrc file in the Dockerfile and wizard crept in.

**Fix Summary:**

Add logical branches to handle the case where the file does not exist
