### PR TITLE
ci: add GitHub main -> GitLab sync MR workflow

### DIFF
--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -43,8 +43,8 @@ jobs:
       # Optional repository variables (set in GitHub -> Settings -> Variables):
       #   GITLAB_TARGET_BRANCH (default: main)
       #   GITLAB_SYNC_BRANCH   (default: github-sync/main)
-      GITLAB_TARGET_BRANCH: ${{ inputs.gitlab_target_branch || vars.GITLAB_TARGET_BRANCH || 'main' }}
-      GITLAB_SYNC_BRANCH: ${{ inputs.gitlab_sync_branch || vars.GITLAB_SYNC_BRANCH || 'github-sync/main' }}
+      GITLAB_TARGET_BRANCH: ${{ github.event.inputs.gitlab_target_branch || vars.GITLAB_TARGET_BRANCH || 'main' }}
+      GITLAB_SYNC_BRANCH: ${{ github.event.inputs.gitlab_sync_branch || vars.GITLAB_SYNC_BRANCH || 'github-sync/main' }}
     steps:
       - name: Validate required secret
         shell: bash
@@ -75,9 +75,9 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           PUSH_BEFORE_SHA: ${{ github.event.before || '' }}
           PUSH_AFTER_SHA: ${{ github.sha }}
-          INPUT_SOURCE_BRANCH: ${{ inputs.source_branch || 'main' }}
-          INPUT_BEFORE_SHA: ${{ inputs.before_sha || '' }}
-          INPUT_AFTER_SHA: ${{ inputs.after_sha || '' }}
+          INPUT_SOURCE_BRANCH: ${{ github.event.inputs.source_branch || 'main' }}
+          INPUT_BEFORE_SHA: ${{ github.event.inputs.before_sha || '' }}
+          INPUT_AFTER_SHA: ${{ github.event.inputs.after_sha || '' }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -248,25 +248,18 @@ jobs:
           set -euo pipefail
 
           API_BASE="https://${GITLAB_HOST}/api/v4"
-          PROJECT_ENCODED="$(python3 - <<'PY'
-import os, urllib.parse
-print(urllib.parse.quote(os.environ["GITLAB_PROJECT_PATH"], safe=""))
-PY
-)"
+          PROJECT_ENCODED="$(python3 -c 'import os, urllib.parse; print(urllib.parse.quote(os.environ["GITLAB_PROJECT_PATH"], safe=""))')"
 
           TITLE="sync(github-main): ${GITHUB_SHA:0:8}"
-          DESCRIPTION="$(cat <<EOF
-Automated sync from GitHub \`main\` to GitLab \`${GITLAB_TARGET_BRANCH}\`.
-
-- GitHub commit: ${GITHUB_SHA}
-- GitHub compare: https://github.com/${GITHUB_REPOSITORY}/compare/${BEFORE_SHA}...${GITHUB_SHA}
-- Workflow run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
-- Excluded paths: \`.github/**\`
-
-This MR branch is force-updated by GitHub Actions:
-\`${SYNC_BRANCH}\`
-EOF
-)"
+          DESCRIPTION="$(printf '%s\n\n- GitHub commit: %s\n- GitHub compare: https://github.com/%s/compare/%s...%s\n- Workflow run: https://github.com/%s/actions/runs/%s\n- Excluded paths: `.github/**`\n\nThis MR branch is force-updated by GitHub Actions:\n`%s`\n' \
+            "Automated sync from GitHub \`main\` to GitLab \`${GITLAB_TARGET_BRANCH}\`." \
+            "${GITHUB_SHA}" \
+            "${GITHUB_REPOSITORY}" \
+            "${BEFORE_SHA}" \
+            "${GITHUB_SHA}" \
+            "${GITHUB_REPOSITORY}" \
+            "${GITHUB_RUN_ID}" \
+            "${SYNC_BRANCH}")"
 
           EXISTING_MR_JSON="$(curl -sS --fail --get \
             --header "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
@@ -275,12 +268,7 @@ EOF
             --data-urlencode "target_branch=${GITLAB_TARGET_BRANCH}" \
             "${API_BASE}/projects/${PROJECT_ENCODED}/merge_requests")"
 
-          EXISTING_IID="$(printf "%s" "${EXISTING_MR_JSON}" | python3 - <<'PY'
-import json, sys
-data = json.load(sys.stdin)
-print(data[0]["iid"] if data else "")
-PY
-)"
+          EXISTING_IID="$(printf "%s" "${EXISTING_MR_JSON}" | python3 -c 'import json, sys; data = json.load(sys.stdin); print(data[0]["iid"] if data else "")')"
 
           if [[ -n "${EXISTING_IID}" ]]; then
             curl -sS --fail --request PUT \
@@ -299,10 +287,6 @@ PY
               --data-urlencode "remove_source_branch=false" \
               "${API_BASE}/projects/${PROJECT_ENCODED}/merge_requests")"
 
-            WEB_URL="$(printf "%s" "${CREATED_JSON}" | python3 - <<'PY'
-import json, sys
-print(json.load(sys.stdin).get("web_url", ""))
-PY
-)"
+            WEB_URL="$(printf "%s" "${CREATED_JSON}" | python3 -c 'import json, sys; print(json.load(sys.stdin).get("web_url", ""))')"
             echo "Created GitLab MR: ${WEB_URL}"
           fi

--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -29,9 +29,9 @@ jobs:
       GITLAB_REPO_URL: ${{ secrets.GITLAB_REPO_URL }}
       # Optional repository variables (set in GitHub -> Settings -> Variables):
       #   GITLAB_TARGET_BRANCH (default: main)
-      #   GITLAB_SYNC_BRANCH   (default: github-sync/main)
+      #   GITLAB_SYNC_BRANCH_PREFIX (default: github-sync/pr-<PR_NUMBER>)
       GITLAB_TARGET_BRANCH: ${{ vars.GITLAB_TARGET_BRANCH || 'main' }}
-      GITLAB_SYNC_BRANCH: ${{ vars.GITLAB_SYNC_BRANCH || 'github-sync/main' }}
+      GITLAB_SYNC_BRANCH_PREFIX: ${{ vars.GITLAB_SYNC_BRANCH_PREFIX || format('github-sync/pr-{0}', github.event.pull_request.number) }}
     steps:
       - name: Fix workspace ownership on self-hosted runner
         shell: bash
@@ -72,6 +72,7 @@ jobs:
         env:
           BEFORE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '' }}
           AFTER_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
 
@@ -145,6 +146,11 @@ jobs:
             exit 0
           fi
 
+          # Unique sync branch per PR head commit.
+          SYNC_BRANCH="${GITLAB_SYNC_BRANCH_PREFIX}-${AFTER_SHA:0:12}"
+          echo "Using sync branch: ${SYNC_BRANCH}"
+          git fetch --quiet --no-tags gitlab "${SYNC_BRANCH}" || true
+
           RANGE="${BEFORE_SHA}..${AFTER_SHA}"
           mapfile -t commits < <(git rev-list --reverse "${RANGE}")
           total="${#commits[@]}"
@@ -156,7 +162,7 @@ jobs:
             exit 0
           fi
 
-          git checkout -B "${GITLAB_SYNC_BRANCH}" "${TARGET_REF}"
+          git checkout -B "${SYNC_BRANCH}" "${TARGET_REF}"
 
           idx=0
           for commit in "${commits[@]}"; do
@@ -233,14 +239,15 @@ jobs:
           done
 
           echo "applied=${applied}" >> "${GITHUB_OUTPUT}"
-          echo "sync_branch=${GITLAB_SYNC_BRANCH}" >> "${GITHUB_OUTPUT}"
+          echo "sync_branch=${SYNC_BRANCH}" >> "${GITHUB_OUTPUT}"
 
           if [[ "${applied}" -eq 0 ]]; then
             echo "No non-excluded changes to sync."
             exit 0
           fi
 
-          git push --force-with-lease gitlab "HEAD:refs/heads/${GITLAB_SYNC_BRANCH}"
+          # Dedicated automation branch: deterministic overwrite is expected.
+          git push --force gitlab "HEAD:refs/heads/${SYNC_BRANCH}"
 
       - name: Create or update GitLab MR
         if: steps.replay.outputs.applied != '0'

--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -117,8 +117,11 @@ jobs:
           fi
 
           git remote add gitlab "${REMOTE_URL}"
-          git fetch --all --prune
-          git fetch gitlab "${GITLAB_TARGET_BRANCH}"
+          # Fetch only the SHAs needed for this PR range from origin.
+          # Keep this quiet to avoid noisy ref output in logs.
+          git fetch --quiet --no-tags origin "${BEFORE_SHA}" "${AFTER_SHA}" || true
+          # Fetch only target branch from GitLab (do not enumerate all refs).
+          git fetch --quiet --no-tags gitlab "${GITLAB_TARGET_BRANCH}"
 
           if [[ -z "${BEFORE_SHA}" || "${BEFORE_SHA}" == "0000000000000000000000000000000000000000" || -z "${AFTER_SHA}" ]]; then
             echo "Unable to determine a valid commit range."

--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -1,9 +1,8 @@
 name: Sync GitHub main -> GitLab MR
 
 on:
-  pull_request:
+  push:
     branches: [main]
-    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
@@ -14,7 +13,6 @@ concurrency:
 
 jobs:
   sync-to-gitlab:
-    if: ${{ github.event.pull_request.head.repo.fork == false }}
     runs-on: [self-hosted, type/docker]
     env:
       # Required secrets:
@@ -29,9 +27,9 @@ jobs:
       GITLAB_REPO_URL: ${{ secrets.GITLAB_REPO_URL }}
       # Optional repository variables (set in GitHub -> Settings -> Variables):
       #   GITLAB_TARGET_BRANCH (default: main)
-      #   GITLAB_SYNC_BRANCH_PREFIX (default: github-sync/pr-<PR_NUMBER>)
+      #   GITLAB_SYNC_BRANCH_PREFIX (default: github-sync/main)
       GITLAB_TARGET_BRANCH: ${{ vars.GITLAB_TARGET_BRANCH || 'main' }}
-      GITLAB_SYNC_BRANCH_PREFIX: ${{ vars.GITLAB_SYNC_BRANCH_PREFIX || format('github-sync/pr-{0}', github.event.pull_request.number) }}
+      GITLAB_SYNC_BRANCH_PREFIX: ${{ vars.GITLAB_SYNC_BRANCH_PREFIX || 'github-sync/main' }}
     steps:
       - name: Fix workspace ownership on self-hosted runner
         shell: bash
@@ -70,9 +68,8 @@ jobs:
         id: replay
         shell: bash
         env:
-          BEFORE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '' }}
-          AFTER_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BEFORE_SHA: ${{ github.event.before || '' }}
+          AFTER_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
 
@@ -254,12 +251,8 @@ jobs:
         shell: bash
         env:
           SYNC_BRANCH: ${{ steps.replay.outputs.sync_branch }}
-          BEFORE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || github.sha }}
-          AFTER_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          PR_BODY: ${{ github.event.pull_request.body || '' }}
+          BEFORE_SHA: ${{ github.event.before || github.sha }}
+          AFTER_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
 
@@ -269,12 +262,10 @@ jobs:
           API_BASE="https://${GITLAB_HOST_NORMALIZED}/api/v4"
           PROJECT_ENCODED="$(python3 -c 'import os, urllib.parse; print(urllib.parse.quote(os.environ["GITLAB_PROJECT_PATH"], safe=""))')"
 
-          TITLE="sync(github-pr #${PR_NUMBER}): ${PR_TITLE}"
+          TITLE="sync(github-main): ${AFTER_SHA:0:12}"
 
-          DESCRIPTION="$(printf '%s\n\n- GitHub PR: %s\n- GitHub PR title: %s\n- GitHub commit: %s\n- GitHub compare: https://github.com/%s/compare/%s...%s\n- Workflow run: https://github.com/%s/actions/runs/%s\n- Excluded paths: `.github/**`\n\nThis MR branch is force-updated by GitHub Actions:\n`%s`\n' \
-            "Automated sync from GitHub PR into GitLab \`${GITLAB_TARGET_BRANCH}\`." \
-            "${PR_URL}" \
-            "${PR_TITLE}" \
+          DESCRIPTION="$(printf '%s\n\n- GitHub commit: %s\n- GitHub compare: https://github.com/%s/compare/%s...%s\n- Workflow run: https://github.com/%s/actions/runs/%s\n- Excluded paths: `.github/**`\n\nThis MR branch is force-updated by GitHub Actions:\n`%s`\n' \
+            "Automated sync from GitHub \`main\` push into GitLab \`${GITLAB_TARGET_BRANCH}\`." \
             "${AFTER_SHA}" \
             "${GITHUB_REPOSITORY}" \
             "${BEFORE_SHA}" \
@@ -282,12 +273,6 @@ jobs:
             "${GITHUB_REPOSITORY}" \
             "${GITHUB_RUN_ID}" \
             "${SYNC_BRANCH}")"
-
-          if [[ -n "${PR_BODY}" ]]; then
-            DESCRIPTION="${DESCRIPTION}"$'\n'"## Original GitHub PR Description"$'\n\n'"${PR_BODY}"
-          else
-            DESCRIPTION="${DESCRIPTION}"$'\n'"## Original GitHub PR Description"$'\n\n'"(No description provided on GitHub PR.)"
-          fi
 
           EXISTING_MR_JSON="$(curl -sS --fail --get \
             --header "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \

--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -21,9 +21,12 @@ jobs:
       #   GITLAB_TOKEN        (PAT with write_repository + api scope)
       #   GITLAB_HOST         (GitLab host, e.g. internal hostname)
       #   GITLAB_PROJECT_PATH (group/project path)
+      # Optional:
+      #   GITLAB_REPO_URL     (full HTTPS Git URL; overrides host/path construction)
       GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
       GITLAB_HOST: ${{ secrets.GITLAB_HOST }}
       GITLAB_PROJECT_PATH: ${{ secrets.GITLAB_PROJECT_PATH }}
+      GITLAB_REPO_URL: ${{ secrets.GITLAB_REPO_URL }}
       # Optional repository variables (set in GitHub -> Settings -> Variables):
       #   GITLAB_TARGET_BRANCH (default: main)
       #   GITLAB_SYNC_BRANCH   (default: github-sync/main)
@@ -62,7 +65,24 @@ jobs:
           set -euo pipefail
 
           TARGET_REF="gitlab/${GITLAB_TARGET_BRANCH}"
-          REMOTE_URL="https://oauth2:${GITLAB_TOKEN}@${GITLAB_HOST}/${GITLAB_PROJECT_PATH}.git"
+
+          # Build GitLab remote URL robustly. If full URL is provided, add auth if needed.
+          if [[ -n "${GITLAB_REPO_URL:-}" ]]; then
+            if [[ "${GITLAB_REPO_URL}" =~ ^https://oauth2: ]]; then
+              REMOTE_URL="${GITLAB_REPO_URL}"
+            elif [[ "${GITLAB_REPO_URL}" =~ ^https:// ]]; then
+              REMOTE_URL="${GITLAB_REPO_URL/https:\/\//https://oauth2:${GITLAB_TOKEN}@}"
+            else
+              echo "GITLAB_REPO_URL must be an https URL if provided."
+              exit 1
+            fi
+          else
+            # Normalize host in case secret includes protocol/path by mistake.
+            GITLAB_HOST_NORMALIZED="${GITLAB_HOST#http://}"
+            GITLAB_HOST_NORMALIZED="${GITLAB_HOST_NORMALIZED#https://}"
+            GITLAB_HOST_NORMALIZED="${GITLAB_HOST_NORMALIZED%%/*}"
+            REMOTE_URL="https://oauth2:${GITLAB_TOKEN}@${GITLAB_HOST_NORMALIZED}/${GITLAB_PROJECT_PATH}.git"
+          fi
 
           # Exclude GitHub-only CI metadata from GitLab.
           EXCLUDE_PATHS=(
@@ -88,6 +108,14 @@ jobs:
 
           git config user.name "GitHub Actions Sync Bot"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          echo "Checking GitLab host DNS..."
+          REMOTE_HOST="$(printf "%s" "${REMOTE_URL}" | sed -E 's#^[a-z]+://([^/@]+@)?([^/:]+).*#\2#')"
+          getent hosts "${REMOTE_HOST}" >/dev/null || {
+            echo "Unable to resolve GitLab host: ${REMOTE_HOST}"
+            echo "If this is an internal host, use a self-hosted runner with internal DNS/VPN access."
+            exit 1
+          }
 
           git remote add gitlab "${REMOTE_URL}"
           git fetch --all --prune
@@ -207,7 +235,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          API_BASE="https://${GITLAB_HOST}/api/v4"
+          GITLAB_HOST_NORMALIZED="${GITLAB_HOST#http://}"
+          GITLAB_HOST_NORMALIZED="${GITLAB_HOST_NORMALIZED#https://}"
+          GITLAB_HOST_NORMALIZED="${GITLAB_HOST_NORMALIZED%%/*}"
+          API_BASE="https://${GITLAB_HOST_NORMALIZED}/api/v4"
           PROJECT_ENCODED="$(python3 -c 'import os, urllib.parse; print(urllib.parse.quote(os.environ["GITLAB_PROJECT_PATH"], safe=""))')"
 
           TITLE="sync(github-pr): ${AFTER_SHA:0:8}"

--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -127,7 +127,11 @@ jobs:
             echo "Continuing; git fetch will provide authoritative connectivity/auth errors."
           fi
 
-          git remote add gitlab "${REMOTE_URL}"
+          if git remote get-url gitlab >/dev/null 2>&1; then
+            git remote set-url gitlab "${REMOTE_URL}"
+          else
+            git remote add gitlab "${REMOTE_URL}"
+          fi
           # Fetch only the SHAs needed for this PR range from origin.
           # Keep this quiet to avoid noisy ref output in logs.
           git fetch --quiet --no-tags origin "${BEFORE_SHA}" "${AFTER_SHA}" || true

--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   sync-to-gitlab:
     if: ${{ github.event.pull_request.head.repo.fork == false }}
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, type/docker]
     env:
       # Required secrets:
       #   GITLAB_TOKEN        (PAT with write_repository + api scope)

--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -33,6 +33,17 @@ jobs:
       GITLAB_TARGET_BRANCH: ${{ vars.GITLAB_TARGET_BRANCH || 'main' }}
       GITLAB_SYNC_BRANCH: ${{ vars.GITLAB_SYNC_BRANCH || 'github-sync/main' }}
     steps:
+      - name: Fix workspace ownership on self-hosted runner
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v sudo >/dev/null 2>&1; then
+            sudo chown -R "$(id -u):$(id -g)" "${GITHUB_WORKSPACE}" || true
+          else
+            chown -R "$(id -u):$(id -g)" "${GITHUB_WORKSPACE}" || true
+          fi
+          chmod -R u+rwX "${GITHUB_WORKSPACE}" || true
+
       - name: Validate required secret
         shell: bash
         run: |

--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -1,0 +1,308 @@
+name: Sync GitHub main -> GitLab MR
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      source_branch:
+        description: "GitHub branch to sync from (for manual testing)"
+        required: false
+        default: "main"
+      before_sha:
+        description: "Optional range start SHA (exclusive)"
+        required: false
+      after_sha:
+        description: "Optional range end SHA (inclusive)"
+        required: false
+      gitlab_target_branch:
+        description: "Optional GitLab MR target branch override"
+        required: false
+      gitlab_sync_branch:
+        description: "Optional GitLab sync branch override"
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gitlab-sync-main
+  cancel-in-progress: true
+
+jobs:
+  sync-to-gitlab:
+    runs-on: ubuntu-22.04
+    env:
+      # Required secrets:
+      #   GITLAB_TOKEN        (PAT with write_repository + api scope)
+      #   GITLAB_HOST         (GitLab host, e.g. internal hostname)
+      #   GITLAB_PROJECT_PATH (group/project path)
+      GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+      GITLAB_HOST: ${{ secrets.GITLAB_HOST }}
+      GITLAB_PROJECT_PATH: ${{ secrets.GITLAB_PROJECT_PATH }}
+      # Optional repository variables (set in GitHub -> Settings -> Variables):
+      #   GITLAB_TARGET_BRANCH (default: main)
+      #   GITLAB_SYNC_BRANCH   (default: github-sync/main)
+      GITLAB_TARGET_BRANCH: ${{ inputs.gitlab_target_branch || vars.GITLAB_TARGET_BRANCH || 'main' }}
+      GITLAB_SYNC_BRANCH: ${{ inputs.gitlab_sync_branch || vars.GITLAB_SYNC_BRANCH || 'github-sync/main' }}
+    steps:
+      - name: Validate required secret
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${GITLAB_TOKEN:-}" ]]; then
+            echo "Missing required secret: GITLAB_TOKEN"
+            exit 1
+          fi
+          if [[ -z "${GITLAB_HOST:-}" ]]; then
+            echo "Missing required secret: GITLAB_HOST"
+            exit 1
+          fi
+          if [[ -z "${GITLAB_PROJECT_PATH:-}" ]]; then
+            echo "Missing required secret: GITLAB_PROJECT_PATH"
+            exit 1
+          fi
+
+      - name: Checkout GitHub main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Replay missing commits onto GitLab sync branch
+        id: replay
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUSH_BEFORE_SHA: ${{ github.event.before || '' }}
+          PUSH_AFTER_SHA: ${{ github.sha }}
+          INPUT_SOURCE_BRANCH: ${{ inputs.source_branch || 'main' }}
+          INPUT_BEFORE_SHA: ${{ inputs.before_sha || '' }}
+          INPUT_AFTER_SHA: ${{ inputs.after_sha || '' }}
+        run: |
+          set -euo pipefail
+
+          TARGET_REF="gitlab/${GITLAB_TARGET_BRANCH}"
+          REMOTE_URL="https://oauth2:${GITLAB_TOKEN}@${GITLAB_HOST}/${GITLAB_PROJECT_PATH}.git"
+
+          # Exclude GitHub-only CI metadata from GitLab.
+          EXCLUDE_PATHS=(
+            ".github"
+          )
+
+          should_exclude_path() {
+            local file="$1"
+            for p in "${EXCLUDE_PATHS[@]}"; do
+              if [[ "${file}" == "${p}" ]] || [[ "${file}" == "${p}/"* ]]; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          is_merge_commit() {
+            local commit="$1"
+            local parent_count
+            parent_count=$(git rev-list --parents -n 1 "${commit}" | awk '{print NF-1}')
+            [[ "${parent_count}" -gt 1 ]]
+          }
+
+          git config user.name "GitHub Actions Sync Bot"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git remote add gitlab "${REMOTE_URL}"
+          SOURCE_BRANCH="${INPUT_SOURCE_BRANCH}"
+          git fetch origin "${SOURCE_BRANCH}"
+          git fetch gitlab "${GITLAB_TARGET_BRANCH}"
+
+          BEFORE_SHA=""
+          AFTER_SHA=""
+
+          if [[ "${EVENT_NAME}" == "push" ]]; then
+            BEFORE_SHA="${PUSH_BEFORE_SHA}"
+            AFTER_SHA="${PUSH_AFTER_SHA}"
+          else
+            # Manual test mode: allow explicit SHAs or infer latest commit on source branch.
+            AFTER_SHA="${INPUT_AFTER_SHA}"
+            if [[ -z "${AFTER_SHA}" ]]; then
+              AFTER_SHA="$(git rev-parse "origin/${SOURCE_BRANCH}")"
+            fi
+
+            BEFORE_SHA="${INPUT_BEFORE_SHA}"
+            if [[ -z "${BEFORE_SHA}" ]]; then
+              BEFORE_SHA="$(git rev-parse "${AFTER_SHA}^" 2>/dev/null || true)"
+            fi
+          fi
+
+          if [[ -z "${BEFORE_SHA}" || "${BEFORE_SHA}" == "0000000000000000000000000000000000000000" || -z "${AFTER_SHA}" ]]; then
+            echo "Unable to determine a valid commit range."
+            echo "EVENT_NAME=${EVENT_NAME} SOURCE_BRANCH=${SOURCE_BRANCH}"
+            echo "BEFORE_SHA=${BEFORE_SHA} AFTER_SHA=${AFTER_SHA}"
+            echo "applied=0" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          RANGE="${BEFORE_SHA}..${AFTER_SHA}"
+          mapfile -t commits < <(git rev-list --reverse "${RANGE}")
+          total="${#commits[@]}"
+          applied=0
+
+          if [[ "${total}" -eq 0 ]]; then
+            echo "No commits found in push range: ${RANGE}"
+            echo "applied=0" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          git checkout -B "${GITLAB_SYNC_BRANCH}" "${TARGET_REF}"
+
+          idx=0
+          for commit in "${commits[@]}"; do
+            idx=$((idx + 1))
+            subject="$(git log -1 --pretty=%s "${commit}")"
+            echo "[${idx}/${total}] Processing ${commit:0:8} ${subject}"
+            cherry_pick_failed=0
+
+            # Apply commit to index/worktree without committing yet.
+            if is_merge_commit "${commit}"; then
+              if ! git cherry-pick -m 1 --no-commit "${commit}"; then
+                echo "Merge-commit cherry-pick failed for ${commit:0:8}"
+                cherry_pick_failed=1
+              fi
+            else
+              if ! git cherry-pick --no-commit "${commit}"; then
+                echo "Cherry-pick failed for ${commit:0:8}"
+                cherry_pick_failed=1
+              fi
+            fi
+
+            # Resolve excluded-path conflicts by keeping current GitLab branch state.
+            mapfile -t conflict_files < <(git diff --name-only --diff-filter=U || true)
+            if [[ "${#conflict_files[@]}" -gt 0 ]]; then
+              included_conflicts=0
+              for f in "${conflict_files[@]}"; do
+                if should_exclude_path "${f}"; then
+                  git checkout --ours -- "${f}" || true
+                  git add "${f}" || true
+                else
+                  included_conflicts=$((included_conflicts + 1))
+                fi
+              done
+              if [[ "${included_conflicts}" -gt 0 ]]; then
+                echo "Non-excluded conflicts detected in ${commit:0:8}; aborting."
+                git status --short
+                git cherry-pick --abort || true
+                exit 1
+              fi
+            fi
+
+            if [[ "${cherry_pick_failed}" -eq 1 && "${#conflict_files[@]}" -eq 0 ]]; then
+              # Empty/already-applied/non-conflict failure; clear state and skip.
+              git cherry-pick --abort || true
+              git reset --hard HEAD
+              echo "Skipping ${commit:0:8}: cherry-pick produced no applicable patch."
+              continue
+            fi
+
+            # Remove excluded paths from staged and working tree.
+            for p in "${EXCLUDE_PATHS[@]}"; do
+              git restore --source=HEAD --staged --worktree -- "${p}" 2>/dev/null || true
+            done
+
+            # Skip empty commit after exclusion.
+            if git diff --cached --quiet && git diff --quiet; then
+              git reset --hard HEAD
+              git cherry-pick --quit || true
+              echo "Skipping ${commit:0:8}: no non-excluded changes remain."
+              continue
+            fi
+
+            author="$(git log -1 --pretty=%an\ <%ae> "${commit}")"
+            author_date="$(git log -1 --pretty=%aI "${commit}")"
+            message="$(git log -1 --pretty=%B "${commit}")"
+            message="${message}"$'\n\n'"(cherry picked from commit ${commit})"
+
+            GIT_AUTHOR_DATE="${author_date}" \
+            GIT_COMMITTER_DATE="${author_date}" \
+              git commit --author="${author}" -F <(printf "%s" "${message}")
+            git cherry-pick --quit || true
+
+            applied=$((applied + 1))
+          done
+
+          echo "applied=${applied}" >> "${GITHUB_OUTPUT}"
+          echo "sync_branch=${GITLAB_SYNC_BRANCH}" >> "${GITHUB_OUTPUT}"
+
+          if [[ "${applied}" -eq 0 ]]; then
+            echo "No non-excluded changes to sync."
+            exit 0
+          fi
+
+          git push --force-with-lease gitlab "HEAD:refs/heads/${GITLAB_SYNC_BRANCH}"
+
+      - name: Create or update GitLab MR
+        if: steps.replay.outputs.applied != '0'
+        shell: bash
+        env:
+          SYNC_BRANCH: ${{ steps.replay.outputs.sync_branch }}
+          BEFORE_SHA: ${{ github.event.before || github.sha }}
+        run: |
+          set -euo pipefail
+
+          API_BASE="https://${GITLAB_HOST}/api/v4"
+          PROJECT_ENCODED="$(python3 - <<'PY'
+import os, urllib.parse
+print(urllib.parse.quote(os.environ["GITLAB_PROJECT_PATH"], safe=""))
+PY
+)"
+
+          TITLE="sync(github-main): ${GITHUB_SHA:0:8}"
+          DESCRIPTION="$(cat <<EOF
+Automated sync from GitHub \`main\` to GitLab \`${GITLAB_TARGET_BRANCH}\`.
+
+- GitHub commit: ${GITHUB_SHA}
+- GitHub compare: https://github.com/${GITHUB_REPOSITORY}/compare/${BEFORE_SHA}...${GITHUB_SHA}
+- Workflow run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+- Excluded paths: \`.github/**\`
+
+This MR branch is force-updated by GitHub Actions:
+\`${SYNC_BRANCH}\`
+EOF
+)"
+
+          EXISTING_MR_JSON="$(curl -sS --fail --get \
+            --header "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
+            --data-urlencode "state=opened" \
+            --data-urlencode "source_branch=${SYNC_BRANCH}" \
+            --data-urlencode "target_branch=${GITLAB_TARGET_BRANCH}" \
+            "${API_BASE}/projects/${PROJECT_ENCODED}/merge_requests")"
+
+          EXISTING_IID="$(printf "%s" "${EXISTING_MR_JSON}" | python3 - <<'PY'
+import json, sys
+data = json.load(sys.stdin)
+print(data[0]["iid"] if data else "")
+PY
+)"
+
+          if [[ -n "${EXISTING_IID}" ]]; then
+            curl -sS --fail --request PUT \
+              --header "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
+              --data-urlencode "title=${TITLE}" \
+              --data-urlencode "description=${DESCRIPTION}" \
+              "${API_BASE}/projects/${PROJECT_ENCODED}/merge_requests/${EXISTING_IID}" >/dev/null
+            echo "Updated existing MR !${EXISTING_IID} in GitLab."
+          else
+            CREATED_JSON="$(curl -sS --fail --request POST \
+              --header "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
+              --data-urlencode "source_branch=${SYNC_BRANCH}" \
+              --data-urlencode "target_branch=${GITLAB_TARGET_BRANCH}" \
+              --data-urlencode "title=${TITLE}" \
+              --data-urlencode "description=${DESCRIPTION}" \
+              --data-urlencode "remove_source_branch=false" \
+              "${API_BASE}/projects/${PROJECT_ENCODED}/merge_requests")"
+
+            WEB_URL="$(printf "%s" "${CREATED_JSON}" | python3 - <<'PY'
+import json, sys
+print(json.load(sys.stdin).get("web_url", ""))
+PY
+)"
+            echo "Created GitLab MR: ${WEB_URL}"
+          fi

--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -111,11 +111,10 @@ jobs:
 
           echo "Checking GitLab host DNS..."
           REMOTE_HOST="$(printf "%s" "${REMOTE_URL}" | sed -E 's#^[a-z]+://([^/@]+@)?([^/:]+).*#\2#')"
-          getent hosts "${REMOTE_HOST}" >/dev/null || {
-            echo "Unable to resolve GitLab host: ${REMOTE_HOST}"
-            echo "If this is an internal host, use a self-hosted runner with internal DNS/VPN access."
-            exit 1
-          }
+          if ! getent hosts "${REMOTE_HOST}" >/dev/null; then
+            echo "Warning: Unable to resolve GitLab host via getent: ${REMOTE_HOST}"
+            echo "Continuing; git fetch will provide authoritative connectivity/auth errors."
+          fi
 
           git remote add gitlab "${REMOTE_URL}"
           git fetch --all --prune

--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -1,26 +1,9 @@
 name: Sync GitHub main -> GitLab MR
 
 on:
-  push:
+  pull_request:
     branches: [main]
-  workflow_dispatch:
-    inputs:
-      source_branch:
-        description: "GitHub branch to sync from (for manual testing)"
-        required: false
-        default: "main"
-      before_sha:
-        description: "Optional range start SHA (exclusive)"
-        required: false
-      after_sha:
-        description: "Optional range end SHA (inclusive)"
-        required: false
-      gitlab_target_branch:
-        description: "Optional GitLab MR target branch override"
-        required: false
-      gitlab_sync_branch:
-        description: "Optional GitLab sync branch override"
-        required: false
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
@@ -31,6 +14,7 @@ concurrency:
 
 jobs:
   sync-to-gitlab:
+    if: ${{ github.event.pull_request.head.repo.fork == false }}
     runs-on: ubuntu-22.04
     env:
       # Required secrets:
@@ -43,8 +27,8 @@ jobs:
       # Optional repository variables (set in GitHub -> Settings -> Variables):
       #   GITLAB_TARGET_BRANCH (default: main)
       #   GITLAB_SYNC_BRANCH   (default: github-sync/main)
-      GITLAB_TARGET_BRANCH: ${{ github.event.inputs.gitlab_target_branch || vars.GITLAB_TARGET_BRANCH || 'main' }}
-      GITLAB_SYNC_BRANCH: ${{ github.event.inputs.gitlab_sync_branch || vars.GITLAB_SYNC_BRANCH || 'github-sync/main' }}
+      GITLAB_TARGET_BRANCH: ${{ vars.GITLAB_TARGET_BRANCH || 'main' }}
+      GITLAB_SYNC_BRANCH: ${{ vars.GITLAB_SYNC_BRANCH || 'github-sync/main' }}
     steps:
       - name: Validate required secret
         shell: bash
@@ -63,7 +47,7 @@ jobs:
             exit 1
           fi
 
-      - name: Checkout GitHub main
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -72,12 +56,8 @@ jobs:
         id: replay
         shell: bash
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          PUSH_BEFORE_SHA: ${{ github.event.before || '' }}
-          PUSH_AFTER_SHA: ${{ github.sha }}
-          INPUT_SOURCE_BRANCH: ${{ github.event.inputs.source_branch || 'main' }}
-          INPUT_BEFORE_SHA: ${{ github.event.inputs.before_sha || '' }}
-          INPUT_AFTER_SHA: ${{ github.event.inputs.after_sha || '' }}
+          BEFORE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '' }}
+          AFTER_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
 
@@ -110,32 +90,11 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           git remote add gitlab "${REMOTE_URL}"
-          SOURCE_BRANCH="${INPUT_SOURCE_BRANCH}"
-          git fetch origin "${SOURCE_BRANCH}"
+          git fetch --all --prune
           git fetch gitlab "${GITLAB_TARGET_BRANCH}"
-
-          BEFORE_SHA=""
-          AFTER_SHA=""
-
-          if [[ "${EVENT_NAME}" == "push" ]]; then
-            BEFORE_SHA="${PUSH_BEFORE_SHA}"
-            AFTER_SHA="${PUSH_AFTER_SHA}"
-          else
-            # Manual test mode: allow explicit SHAs or infer latest commit on source branch.
-            AFTER_SHA="${INPUT_AFTER_SHA}"
-            if [[ -z "${AFTER_SHA}" ]]; then
-              AFTER_SHA="$(git rev-parse "origin/${SOURCE_BRANCH}")"
-            fi
-
-            BEFORE_SHA="${INPUT_BEFORE_SHA}"
-            if [[ -z "${BEFORE_SHA}" ]]; then
-              BEFORE_SHA="$(git rev-parse "${AFTER_SHA}^" 2>/dev/null || true)"
-            fi
-          fi
 
           if [[ -z "${BEFORE_SHA}" || "${BEFORE_SHA}" == "0000000000000000000000000000000000000000" || -z "${AFTER_SHA}" ]]; then
             echo "Unable to determine a valid commit range."
-            echo "EVENT_NAME=${EVENT_NAME} SOURCE_BRANCH=${SOURCE_BRANCH}"
             echo "BEFORE_SHA=${BEFORE_SHA} AFTER_SHA=${AFTER_SHA}"
             echo "applied=0" >> "${GITHUB_OUTPUT}"
             exit 0
@@ -243,20 +202,21 @@ jobs:
         shell: bash
         env:
           SYNC_BRANCH: ${{ steps.replay.outputs.sync_branch }}
-          BEFORE_SHA: ${{ github.event.before || github.sha }}
+          BEFORE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || github.sha }}
+          AFTER_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
 
           API_BASE="https://${GITLAB_HOST}/api/v4"
           PROJECT_ENCODED="$(python3 -c 'import os, urllib.parse; print(urllib.parse.quote(os.environ["GITLAB_PROJECT_PATH"], safe=""))')"
 
-          TITLE="sync(github-main): ${GITHUB_SHA:0:8}"
+          TITLE="sync(github-pr): ${AFTER_SHA:0:8}"
           DESCRIPTION="$(printf '%s\n\n- GitHub commit: %s\n- GitHub compare: https://github.com/%s/compare/%s...%s\n- Workflow run: https://github.com/%s/actions/runs/%s\n- Excluded paths: `.github/**`\n\nThis MR branch is force-updated by GitHub Actions:\n`%s`\n' \
-            "Automated sync from GitHub \`main\` to GitLab \`${GITLAB_TARGET_BRANCH}\`." \
-            "${GITHUB_SHA}" \
+            "Automated sync from GitHub PR into GitLab \`${GITLAB_TARGET_BRANCH}\`." \
+            "${AFTER_SHA}" \
             "${GITHUB_REPOSITORY}" \
             "${BEFORE_SHA}" \
-            "${GITHUB_SHA}" \
+            "${AFTER_SHA}" \
             "${GITHUB_REPOSITORY}" \
             "${GITHUB_RUN_ID}" \
             "${SYNC_BRANCH}")"

--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -215,7 +215,7 @@ jobs:
               continue
             fi
 
-            author="$(git log -1 --pretty=%an\ <%ae> "${commit}")"
+            author="$(git log -1 --pretty=format:'%an <%ae>' "${commit}")"
             author_date="$(git log -1 --pretty=%aI "${commit}")"
             message="$(git log -1 --pretty=%B "${commit}")"
             message="${message}"$'\n\n'"(cherry picked from commit ${commit})"

--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -249,6 +249,10 @@ jobs:
           SYNC_BRANCH: ${{ steps.replay.outputs.sync_branch }}
           BEFORE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || github.sha }}
           AFTER_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
         run: |
           set -euo pipefail
 
@@ -258,9 +262,12 @@ jobs:
           API_BASE="https://${GITLAB_HOST_NORMALIZED}/api/v4"
           PROJECT_ENCODED="$(python3 -c 'import os, urllib.parse; print(urllib.parse.quote(os.environ["GITLAB_PROJECT_PATH"], safe=""))')"
 
-          TITLE="sync(github-pr): ${AFTER_SHA:0:8}"
-          DESCRIPTION="$(printf '%s\n\n- GitHub commit: %s\n- GitHub compare: https://github.com/%s/compare/%s...%s\n- Workflow run: https://github.com/%s/actions/runs/%s\n- Excluded paths: `.github/**`\n\nThis MR branch is force-updated by GitHub Actions:\n`%s`\n' \
+          TITLE="sync(github-pr #${PR_NUMBER}): ${PR_TITLE}"
+
+          DESCRIPTION="$(printf '%s\n\n- GitHub PR: %s\n- GitHub PR title: %s\n- GitHub commit: %s\n- GitHub compare: https://github.com/%s/compare/%s...%s\n- Workflow run: https://github.com/%s/actions/runs/%s\n- Excluded paths: `.github/**`\n\nThis MR branch is force-updated by GitHub Actions:\n`%s`\n' \
             "Automated sync from GitHub PR into GitLab \`${GITLAB_TARGET_BRANCH}\`." \
+            "${PR_URL}" \
+            "${PR_TITLE}" \
             "${AFTER_SHA}" \
             "${GITHUB_REPOSITORY}" \
             "${BEFORE_SHA}" \
@@ -268,6 +275,12 @@ jobs:
             "${GITHUB_REPOSITORY}" \
             "${GITHUB_RUN_ID}" \
             "${SYNC_BRANCH}")"
+
+          if [[ -n "${PR_BODY}" ]]; then
+            DESCRIPTION="${DESCRIPTION}"$'\n'"## Original GitHub PR Description"$'\n\n'"${PR_BODY}"
+          else
+            DESCRIPTION="${DESCRIPTION}"$'\n'"## Original GitHub PR Description"$'\n\n'"(No description provided on GitHub PR.)"
+          fi
 
           EXISTING_MR_JSON="$(curl -sS --fail --get \
             --header "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \

--- a/README.md
+++ b/README.md
@@ -170,3 +170,5 @@ Laura Leal-Taixe, Nicole Yang
   <strong>Built for researchers, by researchers</strong><br>
   <em>Accelerating autonomous vehicle development through realistic simulation</em>
 </div>
+
+Remove after testing: Sync CI test marker: GitHub-to-GitLab workflow validation.


### PR DESCRIPTION
Automate syncing commits pushed to GitHub main into a GitLab MR branch. Exclude GitHub-only CI paths (.github/**), keep GitLab details in secrets, and add workflow_dispatch inputs to test safely before merge.