### PR TITLE
fix: resolve runtime and physics TODOs

### DIFF
--- a/src/physics/tests/test_utils.py
+++ b/src/physics/tests/test_utils.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+
+import numpy as np
+import pytest
+from alpasim_grpc.v0.common_pb2 import AABB, Pose, Quat, Vec3
+from alpasim_physics.utils import (
+    aabb_to_ndarray,
+    ndarray_to_aabb,
+    ndarray_to_pose,
+    ndarray_to_quat,
+    ndarray_to_vec3,
+    pose_grpc_to_ndarray,
+    pose_status_to_grpc,
+    scipy_to_quat,
+    se3_inverse,
+    so3_trans_2_se3,
+)
+from scipy.spatial.transform import Rotation as R
+
+
+class TestVec3Roundtrip:
+    def test_ndarray_to_vec3_and_back(self):
+        original = np.array([1.5, -2.3, 4.7])
+        vec3 = ndarray_to_vec3(original)
+        recovered = np.array([vec3.x, vec3.y, vec3.z])
+        np.testing.assert_array_almost_equal(recovered, original)
+
+    def test_ndarray_to_vec3_zeros(self):
+        original = np.zeros(3)
+        vec3 = ndarray_to_vec3(original)
+        assert vec3.x == 0.0
+        assert vec3.y == 0.0
+        assert vec3.z == 0.0
+
+
+class TestQuatRoundtrip:
+    def test_ndarray_to_quat_and_back(self):
+        # ndarray_to_quat uses [w, x, y, z] ordering
+        original = np.array([0.5, 0.5, 0.5, 0.5])
+        quat = ndarray_to_quat(original)
+        recovered = np.array([quat.w, quat.x, quat.y, quat.z])
+        np.testing.assert_array_almost_equal(recovered, original)
+
+    def test_scipy_to_quat_and_back(self):
+        # scipy_to_quat uses [x, y, z, w] ordering (scipy convention)
+        original = np.array([0.5, 0.5, 0.5, 0.5])
+        quat = scipy_to_quat(original)
+        recovered = np.array([quat.x, quat.y, quat.z, quat.w])
+        np.testing.assert_array_almost_equal(recovered, original)
+
+
+class TestAABBRoundtrip:
+    def test_ndarray_to_aabb_to_ndarray(self):
+        original = np.array([5.0, 2.0, 1.5])
+        aabb = ndarray_to_aabb(original)
+        recovered = aabb_to_ndarray(aabb)
+        np.testing.assert_array_almost_equal(recovered, original)
+
+
+class TestPoseRoundtrip:
+    def test_ndarray_to_pose_to_ndarray(self):
+        """Verify that a pose survives the ndarray -> grpc -> ndarray roundtrip."""
+        rotation = R.from_euler("xyz", [30, 45, 60], degrees=True)
+        translation = np.array([10.0, -5.0, 3.0])
+        se3 = so3_trans_2_se3(rotation.as_matrix(), translation)
+
+        # Convert to grpc via ndarray_to_quat (w, x, y, z)
+        quat_wxyz = np.array(
+            [rotation.as_quat(canonical=False)[3], *rotation.as_quat(canonical=False)[:3]]
+        )
+        grpc_pose = ndarray_to_pose(translation, quat_wxyz)
+
+        # Convert back
+        recovered = pose_grpc_to_ndarray(grpc_pose)
+        np.testing.assert_array_almost_equal(recovered[:3, 3], translation)
+        np.testing.assert_array_almost_equal(recovered[:3, :3], se3[:3, :3], decimal=5)
+
+    def test_identity_pose_roundtrip(self):
+        identity_pose = Pose(
+            vec=Vec3(x=0, y=0, z=0), quat=Quat(w=1, x=0, y=0, z=0)
+        )
+        recovered = pose_grpc_to_ndarray(identity_pose)
+        np.testing.assert_array_almost_equal(recovered, np.eye(4))
+
+
+class TestSE3Inverse:
+    def test_inverse_is_identity(self):
+        rotation = R.from_euler("xyz", [10, 20, 30], degrees=True).as_matrix()
+        translation = np.array([1.0, 2.0, 3.0])
+        T = so3_trans_2_se3(rotation, translation)
+        T_inv = se3_inverse(T)
+        product = T @ T_inv
+        np.testing.assert_array_almost_equal(product, np.eye(4))
+
+    def test_inverse_of_identity_is_identity(self):
+        T_inv = se3_inverse(np.eye(4))
+        np.testing.assert_array_almost_equal(T_inv, np.eye(4))

--- a/src/physics/tests/test_utils.py
+++ b/src/physics/tests/test_utils.py
@@ -2,8 +2,7 @@
 # Copyright (c) 2026 NVIDIA Corporation
 
 import numpy as np
-import pytest
-from alpasim_grpc.v0.common_pb2 import AABB, Pose, Quat, Vec3
+from alpasim_grpc.v0.common_pb2 import Pose, Quat, Vec3
 from alpasim_physics.utils import (
     aabb_to_ndarray,
     ndarray_to_aabb,
@@ -11,7 +10,6 @@ from alpasim_physics.utils import (
     ndarray_to_quat,
     ndarray_to_vec3,
     pose_grpc_to_ndarray,
-    pose_status_to_grpc,
     scipy_to_quat,
     se3_inverse,
     so3_trans_2_se3,
@@ -67,7 +65,10 @@ class TestPoseRoundtrip:
 
         # Convert to grpc via ndarray_to_quat (w, x, y, z)
         quat_wxyz = np.array(
-            [rotation.as_quat(canonical=False)[3], *rotation.as_quat(canonical=False)[:3]]
+            [
+                rotation.as_quat(canonical=False)[3],
+                *rotation.as_quat(canonical=False)[:3],
+            ]
         )
         grpc_pose = ndarray_to_pose(translation, quat_wxyz)
 
@@ -77,9 +78,7 @@ class TestPoseRoundtrip:
         np.testing.assert_array_almost_equal(recovered[:3, :3], se3[:3, :3], decimal=5)
 
     def test_identity_pose_roundtrip(self):
-        identity_pose = Pose(
-            vec=Vec3(x=0, y=0, z=0), quat=Quat(w=1, x=0, y=0, z=0)
-        )
+        identity_pose = Pose(vec=Vec3(x=0, y=0, z=0), quat=Quat(w=1, x=0, y=0, z=0))
         recovered = pose_grpc_to_ndarray(identity_pose)
         np.testing.assert_array_almost_equal(recovered, np.eye(4))
 

--- a/src/runtime/alpasim_runtime/daemon/request_store.py
+++ b/src/runtime/alpasim_runtime/daemon/request_store.py
@@ -17,6 +17,7 @@ class RequestState:
     pending_jobs: int
     results: list[JobResult]
     completion: asyncio.Future[list[JobResult]]
+    abandoned: bool = False
 
 
 class RequestStore:
@@ -86,7 +87,10 @@ class RequestStore:
         try:
             return await state.completion
         except asyncio.CancelledError:
-            # Keep request state alive — jobs may still complete.
+            # Keep request state alive — jobs may still complete.  Mark it
+            # abandoned so the reaper can distinguish it from a request whose
+            # waiter simply hasn't resumed yet after the future resolved.
+            state.abandoned = True
             raise
         finally:
             if state.completion.done():
@@ -102,6 +106,12 @@ class RequestStore:
     def reap_abandoned(self) -> int:
         """Remove completed requests whose waiters were cancelled.
 
+        Only entries explicitly marked ``abandoned`` by a cancelled
+        ``wait_for_completion`` are reaped.  Requests whose future is merely
+        ``done()`` are left alone: the waiter may still be scheduled to
+        resume on the event loop, or the caller may not have called
+        ``wait_for_completion`` yet.
+
         Returns the number of reaped entries.  Safe to call periodically
         (e.g. after each simulation step) to bound memory growth from
         client disconnects.
@@ -109,7 +119,7 @@ class RequestStore:
         abandoned = [
             rid
             for rid, state in self._requests.items()
-            if state.completion.done()
+            if state.abandoned and state.completion.done()
         ]
         for rid in abandoned:
             del self._requests[rid]

--- a/src/runtime/alpasim_runtime/daemon/request_store.py
+++ b/src/runtime/alpasim_runtime/daemon/request_store.py
@@ -87,9 +87,6 @@ class RequestStore:
             return await state.completion
         except asyncio.CancelledError:
             # Keep request state alive — jobs may still complete.
-            # TODO: completed-but-unreaped requests will leak memory. Add an
-            #  explicit cancel/drain path to periodically clean up abandoned
-            #  request state.
             raise
         finally:
             if state.completion.done():
@@ -101,6 +98,27 @@ class RequestStore:
             raise RuntimeError(f"Unknown request_id: {request_id}")
         if not state.completion.done():
             state.completion.set_exception(RuntimeError(message))
+
+    def reap_abandoned(self) -> int:
+        """Remove completed requests whose waiters were cancelled.
+
+        Returns the number of reaped entries.  Safe to call periodically
+        (e.g. after each simulation step) to bound memory growth from
+        client disconnects.
+        """
+        abandoned = [
+            rid
+            for rid, state in self._requests.items()
+            if state.completion.done()
+        ]
+        for rid in abandoned:
+            del self._requests[rid]
+        return len(abandoned)
+
+    @property
+    def active_request_count(self) -> int:
+        """Number of requests currently tracked (pending + abandoned)."""
+        return len(self._requests)
 
     def fail_all_requests(self, message: str) -> None:
         for state in self._requests.values():

--- a/src/runtime/alpasim_runtime/daemon/scheduler.py
+++ b/src/runtime/alpasim_runtime/daemon/scheduler.py
@@ -166,6 +166,10 @@ class DaemonScheduler:
         release_all(pools, acquired)
         self._request_store.record_result(result)
 
+        reaped = self._request_store.reap_abandoned()
+        if reaped:
+            logger.info("Reaped %d abandoned request(s)", reaped)
+
     async def _dispatch_loop(self) -> None:
         """Background loop that processes completed jobs and re-dispatches.
 

--- a/src/runtime/alpasim_runtime/types.py
+++ b/src/runtime/alpasim_runtime/types.py
@@ -52,7 +52,8 @@ class Clock:
 
     def ith_trigger(self, i: int) -> Trigger:
         """Returns the i-th trigger of the clock since self.start_us"""
-        # TODO(mwatson): raise if i is negative???
+        if i < 0:
+            raise ValueError(f"Trigger index must be non-negative, got {i}")
         return Clock.Trigger(
             range(
                 self.start_us + i * self.interval_us,

--- a/src/runtime/tests/test_daemon_request_store.py
+++ b/src/runtime/tests/test_daemon_request_store.py
@@ -90,3 +90,37 @@ async def test_request_store_too_many_results_raises() -> None:
 
     with pytest.raises(RuntimeError, match="Too many results recorded"):
         store.record_result(_make_result("req-1", "job-2"))
+
+
+@pytest.mark.asyncio
+async def test_request_store_reap_abandoned_cleans_cancelled_waiters() -> None:
+    store = RequestStore()
+    await store.register_request("req-1", expected_jobs=1)
+
+    waiter = asyncio.create_task(store.wait_for_completion("req-1"))
+    await asyncio.sleep(0)
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+
+    # Request state is still tracked (the leak scenario).
+    assert store.active_request_count == 1
+
+    # Complete the jobs so the future is done.
+    store.record_result(_make_result("req-1", "job-1"))
+
+    # Reap should clean up the completed-but-unreaped entry.
+    reaped = store.reap_abandoned()
+    assert reaped == 1
+    assert store.active_request_count == 0
+
+
+@pytest.mark.asyncio
+async def test_request_store_reap_abandoned_ignores_pending() -> None:
+    store = RequestStore()
+    await store.register_request("req-1", expected_jobs=1)
+
+    # Request is still pending (no results yet) — should not be reaped.
+    reaped = store.reap_abandoned()
+    assert reaped == 0
+    assert store.active_request_count == 1

--- a/src/runtime/tests/test_daemon_request_store.py
+++ b/src/runtime/tests/test_daemon_request_store.py
@@ -124,3 +124,29 @@ async def test_request_store_reap_abandoned_ignores_pending() -> None:
     reaped = store.reap_abandoned()
     assert reaped == 0
     assert store.active_request_count == 1
+
+
+@pytest.mark.asyncio
+async def test_request_store_reap_abandoned_ignores_done_but_unawaited() -> None:
+    """Results may arrive before the caller awaits wait_for_completion.
+
+    In that window the future is done() but the request is not abandoned —
+    the reaper must leave it alone so the pending waiter can still retrieve
+    its results.
+    """
+    store = RequestStore()
+    await store.register_request("req-1", expected_jobs=1)
+
+    # Results arrive before any waiter is scheduled.
+    store.record_result(_make_result("req-1", "job-1"))
+    assert store.active_request_count == 1
+
+    # Reap must NOT remove this entry — no cancelled waiter.
+    reaped = store.reap_abandoned()
+    assert reaped == 0
+    assert store.active_request_count == 1
+
+    # The caller can still retrieve its results.
+    results = await store.wait_for_completion("req-1")
+    assert len(results) == 1
+    assert store.active_request_count == 0

--- a/src/runtime/tests/test_types.py
+++ b/src/runtime/tests/test_types.py
@@ -41,6 +41,11 @@ def test_clock_ith_trigger(clock_10_1_25):
     assert trigger.sequential_idx == 1
 
 
+def test_clock_ith_trigger_negative_index_raises(clock_10_1_25):
+    with pytest.raises(ValueError, match="non-negative"):
+        clock_10_1_25.ith_trigger(-1)
+
+
 def test_clock_last_trigger(clock_10_1_25):
     times_trigger_is_25 = [25, 26, 27]
     times_trigger_is_35 = [35, 36, 37]


### PR DESCRIPTION
## Summary
- **Clock.ith_trigger negative index guard** — `ith_trigger(-1)` now raises `ValueError` instead of silently producing nonsensical time ranges (resolves TODO in `types.py:55`)
- **RequestStore memory leak fix** — Adds `reap_abandoned()` method to clean up completed-but-unreaped request state from cancelled waiters, plus `active_request_count` property for observability (resolves TODO in `request_store.py:90`)
- **Physics utils roundtrip tests** — New `test_utils.py` covering `Vec3`, `Quat`, `AABB`, `Pose` ndarray↔protobuf roundtrips and `SE3` inverse correctness (resolves TODO in `utils.py:31`)

## Test plan
- [ ] `uv run pytest src/runtime/tests/test_types.py` — verify negative index raises ValueError
- [ ] `uv run pytest src/runtime/tests/test_daemon_request_store.py` — verify reap_abandoned cleans up leaked state, ignores pending requests
- [ ] `uv run pytest src/physics/tests/test_utils.py` — verify all roundtrip conversions preserve values
- [ ] `pre-commit run --all-files` — lint passes