### PR TITLE
fix(eval): check union of nearby lanes for offroad detection

### DIFF
--- a/src/eval/src/eval/scorers/offroad.py
+++ b/src/eval/src/eval/scorers/offroad.py
@@ -6,6 +6,7 @@ from typing import Literal, Optional
 import numpy as np
 import shapely
 import shapely.geometry
+import shapely.ops
 from alpasim_utils import geometry
 from matplotlib import pyplot as plt
 from shapely import plotting as shapely_plotting
@@ -145,6 +146,21 @@ class OffRoadScorer(Scorer):
             if len(res["curr_lanes_containing_polygon"]) > 0:
                 offroad.append(False)
                 continue
+
+            # When straddling two adjacent lanes (e.g. during a lane change
+            # across a dashed line), no single lane fully contains the ego
+            # polygon.  Check whether the union of all nearby lane polygons
+            # covers it instead (see GitHub issue #61).
+            if len(res["possible_current_lanes"]) > 1:
+                lane_union = shapely.ops.unary_union(
+                    [
+                        _get_lane_polygon(lane)
+                        for lane in res["possible_current_lanes"]
+                    ]
+                )
+                if lane_union.contains(ego_polygon):
+                    offroad.append(False)
+                    continue
 
             # Check if we're too close to the road edge. This will still miss
             # offroad cases when we're far outside the road - but then either


### PR DESCRIPTION
## Summary
Addresses #61 — Inconsistent BEV lane semantics causing incorrect offroad detection.

The current offroad detection checks if any **single** lane fully contains the ego polygon. During lane changes (crossing dashed lines), the vehicle straddles two adjacent lanes — neither fully contains it, triggering a false offroad event.

**Fix**: After the single-lane containment check fails, compute the **union** of all nearby lane polygons via `shapely.ops.unary_union` and check if the combined geometry covers the ego polygon. This correctly handles:
- Lane changes across dashed lines
- Narrow roads where the ego partially overlaps adjacent lanes
- Cases where BEV lane boundaries have slight inaccuracies

This is a code-level mitigation. The underlying BEV data quality issues (dashed vs solid misclassification, incorrect rural road centerlines) are data-side problems that require map/annotation fixes.

## Changed files
- `src/eval/src/eval/scorers/offroad.py` — Add lane union containment check as fallback

## Test plan
- [x] `uv run pytest src/eval/tests/ -v`
- [x] Verify with replays from #61 that false offroad events during lane changes are eliminated
- [x] Confirm genuine offroad events (vehicle fully outside all lanes) are still detected