### PR TITLE
ci: cancel stale runs when PRs are updated

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     # Run on all PRs (matches GitLab merge_request_event for lint)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-22.04

--- a/.github/workflows/pre.yml
+++ b/.github/workflows/pre.yml
@@ -23,6 +23,10 @@ on:
         description: "Optional driver image override"
         required: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,10 @@ on:
         required: false
         default: "false"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Add workflow-level concurrency to lint, pre, and test GitHub Actions so in-progress runs for older commits are automatically canceled when new commits are pushed to the same PR or branch. This keeps CI focused on the latest revision, reduces runner usage, and shortens feedback time.