### PR TITLE
Fix GitHub to GitLab sync to preserve GitLab CI files

### DIFF
--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -94,8 +94,11 @@ jobs:
           fi
 
           # Exclude GitHub-only CI metadata from GitLab.
+          # Also exclude GitLab-only CI files to prevent deletion.
           EXCLUDE_PATHS=(
             ".github"
+            ".gitlab-ci.yml"
+            "plugins/internal"
           )
 
           should_exclude_path() {
@@ -264,7 +267,7 @@ jobs:
 
           TITLE="sync(github-main): ${AFTER_SHA:0:12}"
 
-          DESCRIPTION="$(printf '%s\n\n- GitHub commit: %s\n- GitHub compare: https://github.com/%s/compare/%s...%s\n- Workflow run: https://github.com/%s/actions/runs/%s\n- Excluded paths: `.github/**`\n\nThis MR branch is force-updated by GitHub Actions:\n`%s`\n' \
+          DESCRIPTION="$(printf '%s\n\n- GitHub commit: %s\n- GitHub compare: https://github.com/%s/compare/%s...%s\n- Workflow run: https://github.com/%s/actions/runs/%s\n- Excluded paths: `.github/**`, `.gitlab-ci.yml`, `plugins/internal/**`\n\nThis MR branch is force-updated by GitHub Actions:\n`%s`\n' \
             "Automated sync from GitHub \`main\` push into GitLab \`${GITLAB_TARGET_BRANCH}\`." \
             "${AFTER_SHA}" \
             "${GITHUB_REPOSITORY}" \


### PR DESCRIPTION
The automated sync workflow from GitHub to GitLab was attempting to delete GitLab-specific CI files (.gitlab-ci.yml and plugins/internal/) because these files don't exist in the GitHub repository and weren't being excluded from the sync operation.

This created an asymmetry where GitLab->GitHub sync correctly excluded GitLab-only files, but GitHub->GitLab sync only excluded .github/ and would try to apply deletions for any GitLab-specific files.

Changes:
- Add .gitlab-ci.yml and plugins/internal to EXCLUDE_PATHS array
- Update MR description template to document all excluded paths

This ensures bidirectional sync properly preserves platform-specific CI/CD infrastructure files in both directions.