### PR TITLE
Fix Windows file-locking error

### DIFF
--- a/src/controller/alpasim_controller/system.py
+++ b/src/controller/alpasim_controller/system.py
@@ -80,6 +80,15 @@ class System:
         self._solve_time_ms: float = 0.0
         self._last_mpc_time_us: int | None = None
 
+    def close(self) -> None:
+        """Close the CSV log file handle.
+
+        Callers must close before removing ``log_file`` on Windows, where open
+        files cannot be deleted.
+        """
+        if not self._log_file_handle.closed:
+            self._log_file_handle.close()
+
     def _dynamic_state_to_cg_velocity(
         self, dynamic_state: common_pb2.DynamicState
     ) -> np.ndarray:

--- a/src/controller/tests/test_create_system_registry.py
+++ b/src/controller/tests/test_create_system_registry.py
@@ -35,6 +35,7 @@ def test_create_system_via_registry(mpc_impl: MPCImplementation) -> None:
     """create_system() returns a System with a controller from the plugin registry."""
     with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
         log_file = f.name
+    system = None
     try:
         initial_state = _make_initial_state()
         system = create_system(
@@ -46,5 +47,7 @@ def test_create_system_via_registry(mpc_impl: MPCImplementation) -> None:
         assert hasattr(system, "_controller")
         assert hasattr(system._controller, "compute_control")
     finally:
+        if system is not None:
+            system.close()
         if os.path.exists(log_file):
             os.unlink(log_file)


### PR DESCRIPTION
On Windows, open file handles cannot be deleted, unlike Linux. System opened a temporary CSV log file but had no close() method, causing os.unlink() to fail in tests.

Changes made:
Added System.close() to system.py to release the CSV log handle
Updated test_create_system_registry.py to initialize system = None before try, then call system.close() in finally before unlinking the temp file.

This fixes the cross-platform inconsistency where tests passed in Linux CI but failed locally on Windows.