### PR TITLE
Fix stale NuRec 25.07 dataset links in docs

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -5,7 +5,7 @@ Alpasim depends on access to the following:
 - Hugging Face access
   - Used for downloading simulation artifacts
   - Data is
-    [here](https://huggingface.co/datasets/nvidia/PhysicalAI-Autonomous-Vehicles-NuRec/tree/main/sample_set/25.07_release)
+    [here](https://huggingface.co/datasets/nvidia/PhysicalAI-Autonomous-Vehicles-NuRec/tree/25.07/sample_set/25.07_release)
   - See info on data
     [here](https://huggingface.co/datasets/nvidia/PhysicalAI-Autonomous-Vehicles-NuRec/blob/main/README.md#dataset-format)
     for more information on the contents of artifacts used to define scenes

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -347,7 +347,7 @@ the predictions of a policy, you can set
 The scene in AlpaSim is a NuRec reconstruction of a real-world driving log.
 
 Publicly available NuRec scenes are stored on
-[Hugging Face](https://huggingface.co/datasets/nvidia/PhysicalAI-Autonomous-Vehicles-NuRec/tree/main/sample_set/25.07_release)
+[Hugging Face](https://huggingface.co/datasets/nvidia/PhysicalAI-Autonomous-Vehicles-NuRec/tree/25.07/sample_set/25.07_release)
 and, once downloaded, are placed under `data/nre-artifacts/all-usdzs`. The scenes are identified by
 their uuid, rather than their filenames, to prevent versioning issues. The list of currently
 available scenes exists in [scenes set](/data/scenes/sim_scenes.csv) and the set of available suites


### PR DESCRIPTION
Update the Hugging Face NuRec 25.07 sample set links to point at the
25.07 branch instead of main.

The previous main-branch URLs no longer resolve because the 25.07 release
was removed from main.