### PR TITLE
Enable copy-pr-bot for self-hosted PR CI

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,0 +1,3 @@
+enabled: true
+auto_sync_draft: false
+auto_sync_ready: true

--- a/.github/scripts/changed-files.sh
+++ b/.github/scripts/changed-files.sh
@@ -6,8 +6,35 @@ set -euo pipefail
 EVENT_NAME="${1:-${GITHUB_EVENT_NAME:-}}"
 BASE_SHA="${2:-}"
 HEAD_SHA="${3:-${GITHUB_SHA:-HEAD}}"
+DEFAULT_BRANCH="${4:-${GITHUB_DEFAULT_BRANCH:-main}}"
 
 ZERO_SHA="0000000000000000000000000000000000000000"
+REF_NAME="${GITHUB_REF_NAME:-}"
+if [[ -z "${REF_NAME}" && "${GITHUB_REF:-}" == refs/heads/* ]]; then
+  REF_NAME="${GITHUB_REF#refs/heads/}"
+fi
+
+# copy-pr-bot mirrors trusted PRs into pull-request/<number> branches and
+# triggers CI via push. Diff those branches against the default branch rather
+# than against the previous mirror push.
+if [[ "${REF_NAME}" == pull-request/* ]]; then
+  BASE_REF=""
+  if git rev-parse --verify --quiet "origin/${DEFAULT_BRANCH}^{commit}" >/dev/null; then
+    BASE_REF="origin/${DEFAULT_BRANCH}"
+  elif git rev-parse --verify --quiet "${DEFAULT_BRANCH}^{commit}" >/dev/null; then
+    BASE_REF="${DEFAULT_BRANCH}"
+  fi
+
+  if [[ -n "${BASE_REF}" ]]; then
+    MERGE_BASE="$(git merge-base "${BASE_REF}" "${HEAD_SHA}" 2>/dev/null || true)"
+    if [[ -n "${MERGE_BASE}" ]]; then
+      git diff --name-only "${MERGE_BASE}" "${HEAD_SHA}"
+      exit 0
+    fi
+  fi
+
+  echo "Default branch ${DEFAULT_BRANCH} is not available; using fallback diff." >&2
+fi
 
 # Initial pipeline or missing base SHA: return all tracked files so downstream
 # steps still run instead of failing due to no diff baseline.

--- a/.github/workflows/pre.yml
+++ b/.github/workflows/pre.yml
@@ -1,9 +1,8 @@
 name: Pre Stage
 
 on:
-  pull_request:
   push:
-    branches: [main, master]
+    branches: [main, master, "pull-request/[0-9]+"]
   workflow_dispatch:
     inputs:
       pipeline_target:
@@ -24,7 +23,7 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -74,16 +73,14 @@ jobs:
           RCLONE_REMOTE_AUTH_VERSION="1"
           DEFAULT_ALPACKAGES_PATH="alpasim/artifacts/alpackages/25.10.08"
 
-          # PRs diff against base->head; pushes diff previous SHA->current SHA.
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
-            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-          else
-            BASE_SHA="${{ github.event.before }}"
-            HEAD_SHA="${{ github.sha }}"
-          fi
+          BASE_SHA="${{ github.event.before }}"
+          HEAD_SHA="${{ github.sha }}"
 
-          CHANGED_FILES="$(bash ./.github/scripts/changed-files.sh "${{ github.event_name }}" "${BASE_SHA}" "${HEAD_SHA}")"
+          CHANGED_FILES="$(bash ./.github/scripts/changed-files.sh \
+            "${{ github.event_name }}" \
+            "${BASE_SHA}" \
+            "${HEAD_SHA}" \
+            "${{ github.event.repository.default_branch }}")"
 
           CHANGED_SERVICES=""
           for service in ${DOCKER_SERVICES}; do
@@ -132,7 +129,7 @@ jobs:
   bump-versions-plan:
     # Safe first step: report what would be bumped on PRs to default branch.
     # We can replace with commit/push behavior later.
-    if: github.event_name == 'pull_request' && github.base_ref == github.event.repository.default_branch
+    if: startsWith(github.ref, 'refs/heads/pull-request/')
     runs-on: ubuntu-22.04
     needs: [prepare-variables]
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,8 @@
 name: Test Stage
 
 on:
-  pull_request:
   push:
-    branches: [main, master]
+    branches: [main, master, "pull-request/[0-9]+"]
   workflow_dispatch:
     inputs:
       enable_infra_tests:
@@ -12,7 +11,7 @@ on:
         default: "false"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -147,15 +146,14 @@ jobs:
           set -euo pipefail
           SERVICE="${{ matrix.service }}"
 
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
-            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-          else
-            BASE_SHA="${{ github.event.before }}"
-            HEAD_SHA="${{ github.sha }}"
-          fi
+          BASE_SHA="${{ github.event.before }}"
+          HEAD_SHA="${{ github.sha }}"
 
-          CHANGED_FILES="$(bash ./.github/scripts/changed-files.sh "${{ github.event_name }}" "${BASE_SHA}" "${HEAD_SHA}")"
+          CHANGED_FILES="$(bash ./.github/scripts/changed-files.sh \
+            "${{ github.event_name }}" \
+            "${BASE_SHA}" \
+            "${HEAD_SHA}" \
+            "${{ github.event.repository.default_branch }}")"
 
           # Build only when service source changed; otherwise this stage is a no-op.
           SOURCE="stable"


### PR DESCRIPTION
Add the repository-side copy-pr-bot configuration and move self-hosted
pre/test workflows off direct pull_request execution. The workflows now run on
pushes to mirrored pull-request/<number> branches, while main/master pushes
and manual dispatch remain supported.

Update changed-file detection so mirrored PR branches diff against the default
branch merge base instead of the previous mirror push.