### PR TITLE
Bugfix: Remove wrong artifact cache override; add a note on system start time…

### DIFF
--- a/docs/VIDEO_MODEL.md
+++ b/docs/VIDEO_MODEL.md
@@ -96,6 +96,8 @@ uv run --project src/wizard alpasim_wizard \
   wizard.log_dir=$PWD/outputs/managed-flashdreams-vavam-run
 ```
 
+> :warning: the initial run will download large model checkpoints to a local cache. Consider setting `+runtime.endpoints.startup_timeout_s=600` or more to prevent premature timeout on your first run.
+
 `driver=vavam_video_model` uses the same VaVam model and camera selection as
 `driver=vavam`, but skips the local camera calibration override that is only
 valid for the default NuRec renderer. Video-model sessions use the recorded

--- a/src/wizard/configs/deploy/managed_flashdreams.yaml
+++ b/src/wizard/configs/deploy/managed_flashdreams.yaml
@@ -45,7 +45,6 @@ services:
 # Default to the public OmniDreams scene pack; see docs/VIDEO_MODEL.md for
 # download/setup notes.
 scenes:
-  local_usdz_dir: ${repo-relative:"data/omni-dreams-scenes/scenes"}
   nre_version_string: "25.7.9-b85d0efd"
   scene_ids:
     - clipgt-01d503d4-449b-46fc-8d78-9085e70d3554


### PR DESCRIPTION
* Remove wrong artifact cache override in `flashdreams_managed.yaml`
* Add a note on system start timeout in the initial run in `docs/VIDEO_MODEL.md`