### PR TITLE
Sync from GitLab (2026-06-12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ Suitable use cases include:
 
 ### **Sensor Fidelity**
 
-- Neural Rendering (NuRec) integration for photorealistic sensor simulation of novel views
+- Pluggable renderer service with default [NuRec](https://docs.nvidia.com/nurec/) support and
+  [OmniDreams](https://github.com/nv-tlabs/omni-dreams) video-model rendering through
+  [FlashDreams](https://github.com/NVIDIA/flashdreams)
 - High-fidelity camera feeds with configurable field-of-view, resolution, and frame rates
+- Stateful video-model rendering for stronger dynamic-object and non-rigid visual fidelity
 - Realistic sensor noise and environmental conditions
 
 ### **Research Hackability**
@@ -60,6 +63,8 @@ appreciated.
 ## Getting Started
 
 To run simulations locally (Docker Compose, single machine), see the [Tutorial](docs/TUTORIAL.md).
+The default tutorial path uses NuRec; for OmniDreams as the renderer backend, see the
+[Video Model Renderer guide](docs/VIDEO_MODEL.md).
 For cluster or SLURM deployment, see `src/tools/run-on-slurm`.
 
 ## Documentation & Resources
@@ -67,6 +72,8 @@ For cluster or SLURM deployment, see `src/tools/run-on-slurm`.
 - **[Onboarding Guide](docs/ONBOARDING.md)**: Initial setup and access instructions
 - **[Tutorial](docs/TUTORIAL.md)**: Step-by-step usage guide
 - **[Manual Driver](docs/MANUAL_DRIVER.md)**: Interactive keyboard control of the ego vehicle
+- **[Video Model Renderer](docs/VIDEO_MODEL.md)**: Running OmniDreams through FlashDreams as the
+  AlpaSim renderer backend
 - **[Operations Guide](docs/OPERATIONS.md)**: Performance tuning, configuration, and troubleshooting
 - **[Data Pipeline](docs/DATA_PIPELINE.md)**: ASL log format and reading logs
 - **[Design Documentation](docs/DESIGN.md)**: Technical architecture and design decisions

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -11,14 +11,14 @@ Real-time and very precise physics are non-goals.
 For these reasons we implement Alpasim as a collection of microservices (enabling scalability) which
 are implemented in Python (accessible to researchers) and communicate via gRPC.
 
-Core services include the
-[Neural Rendering Engine (NRE)](https://www.nvidia.com/en-us/glossary/3d-reconstruction/) and neural
-traffic simulator (coming soon). Additionally, we have a [physics simulation module](/src/physics)
-(ground constraints for egovehicle and non-ego actors), a
-[controller/vehicle model](/src/controller), and a
-[runtime](/src/runtime) which drives the simulation
-loop by issuing calls to the respective services and produces logs. An [eval module](/src/eval) runs
-outside of the main simulation loop and consumes the logs to compute metrics for autonomous driving.
+Core services include a renderer service, neural traffic simulator (coming soon), a
+[physics simulation module](/src/physics) (ground constraints for egovehicle and non-ego actors), a
+[controller/vehicle model](/src/controller), and a [runtime](/src/runtime) which drives the
+simulation loop by issuing calls to the respective services and produces logs. The default renderer
+uses the [Neural Rendering Engine (NRE)](https://www.nvidia.com/en-us/glossary/3d-reconstruction/),
+and the same `renderer` endpoint can also be backed by the
+[OmniDreams video-model renderer](VIDEO_MODEL.md). An [eval module](/src/eval) runs outside of the
+main simulation loop and consumes the logs to compute metrics for autonomous driving.
 
 The simulator interfaces with [a driver](/src/driver) - the egovehicle policy network, which is the
 main target of the simulation and creates trajectories to complete the feedback loop. The services
@@ -34,7 +34,7 @@ The diagram illustrates the logical flow of the simulation instance
 - **Runtime** keeps track of the world state
 - The world state is fed as bounding boxes to **trafficsim**, which actuates non-ego actors
   (pedestrians, vehicles, etc)
-- The world state is also used by **NRE** to produce camera frames for the ego vehicle
+- The world state is also used by the **renderer** to produce camera frames for the ego vehicle
 - Sensor readings are used by the **driver** to make decisions about actuating the ego vehicle
 - The actuation request (planned path) is fed to the **controller**, which models the vehicle
   controller and dynamics, providing (uncorrected) egomotion
@@ -45,7 +45,7 @@ The diagram illustrates the logical flow of the simulation instance
 
 The software implementation places the runtime at the center, as a node for all communications. The
 remaining services can be replicated according to their computational requirements (in general
-`ego policy > sensor sim > controller sim > traffic sim > physics sim`). This design facilitates
+`ego policy > renderer > controller sim > traffic sim > physics sim`). This design facilitates
 synchronized logging and lets the runtime double as a load balancer between the replicas of
 remaining services but it also means that the runtime is about as IO intense as all other services
 _combined_.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -34,6 +34,23 @@ Alpasim depends on access to the following:
 - Install the NVIDIA Container Toolkit (see
   [here](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html))
 
+## Optional: OmniDreams video-model renderer
+
+The default AlpaSim tutorial uses NuRec. To use
+[OmniDreams](https://github.com/nv-tlabs/omni-dreams) as the renderer backend, follow the
+[Video Model Renderer guide](VIDEO_MODEL.md) after completing the base setup above.
+
+Additional requirements for this path:
+
+- A [FlashDreams](https://github.com/NVIDIA/flashdreams) checkout and a locally built
+  `flashdreams-alpasim:local` image for `deploy=managed_flashdreams`, or access to an external
+  OmniDreams gRPC server for `deploy=external_video_model`.
+- Hugging Face authentication for any gated OmniDreams, FlashDreams, driver, or scene assets needed
+  by the selected run.
+- Enough GPU memory for both the renderer and the selected driver. The managed FlashDreams preset
+  currently requires about 48 GB VRAM with the lightweight public single-view driver preset and
+  about 96 GB VRAM with the Alpamayo1.5 single-camera preset.
+
 ## Dependency management
 
 The repo is a [uv workspace](https://docs.astral.sh/uv/concepts/workspaces/). All packages under `src/` and `plugins/` are workspace members sharing a single lockfile (`uv.lock`). The root `pyproject.toml` has empty `dependencies`, so a bare `uv sync` installs nothing -- this is intentional to avoid pulling heavy dependencies (torch, warp-lang) by default.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -10,6 +10,12 @@ The number of service replicas and their GPU assignments are configured in deplo
 located in `src/wizard/configs/deploy/`:
 
 - **Local workstation**: `local.yaml`
+- **Wizard-managed OmniDreams renderer**: `managed_flashdreams.yaml`
+- **External OmniDreams renderer**: `external_video_model.yaml`
+
+The default renderer path is NuRec-backed. OmniDreams runs use FlashDreams behind the same
+`renderer` endpoint; see [VIDEO_MODEL.md](VIDEO_MODEL.md) for the renderer-specific chunking,
+camera, and deployment constraints.
 
 #### Understanding the Configuration
 
@@ -91,6 +97,11 @@ For NRE-backed renderer deployments, tune these together:
 - `runtime.endpoints.renderer.n_concurrent_rollouts`
 
 Recent OSS deploy configs prefer `replicas_per_container: 1` plus higher `--max-workers`.
+
+For OmniDreams/FlashDreams deployments, start with
+`runtime.endpoints.renderer.n_concurrent_rollouts=1` and the `+chunking=8frame` preset from
+[VIDEO_MODEL.md](VIDEO_MODEL.md). Scale only after the
+renderer server, driver cadence, and GPU memory headroom are known to be stable.
 
 ### How do I change the model?
 

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -18,7 +18,9 @@ AlpaSim consists of multiple networked microservices (renderer, physics simulati
 controller, driver, traffic simulation). The AlpaSim runtime requests observed video frames from the
 renderer and egomotion history from the controller, communicates with the physics microservice to
 constrain actors to the road surface, and provides the information to the driver, with the
-expectation of receiving driving decisions in return to close the loop.
+expectation of receiving driving decisions in return to close the loop. The default renderer uses
+NuRec, and the same `renderer` service interface can also be backed by OmniDreams through
+FlashDreams.
 
 This repository contains the implementations of a subset of the services needed to execute the
 simulation as well as config files and infra code necessary to bring the microservices up via
@@ -198,6 +200,25 @@ By default, the wizard launches and owns the configured driver service. Use
 Additionally, service-specific config groups can override the default images and launch behavior,
 for example `physics=disabled`.
 
+### Renderer options
+
+The tutorial run above uses the default NuRec-backed renderer. AlpaSim can also use
+[OmniDreams](https://github.com/nv-tlabs/omni-dreams) through
+[FlashDreams](https://github.com/NVIDIA/flashdreams) as a stateful video-model renderer behind the
+same `renderer` endpoint.
+
+| Renderer path | Main config entry point | Notes |
+|---------------|-------------------------|-------|
+| Default NuRec renderer | `deploy=local` | Best starting point for the basic tutorial and broad public scene coverage. |
+| Wizard-managed OmniDreams renderer | `deploy=managed_flashdreams` | Wizard starts a local FlashDreams renderer container. Requires a locally built FlashDreams image. |
+| External OmniDreams renderer | `deploy=external_video_model` | AlpaSim connects to an OmniDreams gRPC server running elsewhere. Useful when renderer GPUs live on another machine. |
+
+The active renderer is selected through the deploy config and materializes in
+`runtime.renderer.kind`; OmniDreams runs use `runtime.renderer.kind=video_model`. The driver remains
+a separate service, but the current public OmniDreams recipe is single-view, so use one of the
+known-compatible driver presets and timing presets documented in
+[VIDEO_MODEL.md](VIDEO_MODEL.md) instead of adding camera overrides by hand.
+
 # Level 2
 
 In level 2 we learn to customize the simulation (i.e. change the driver policy, change simulated
@@ -344,9 +365,12 @@ the predictions of a policy, you can set
 
 ## Scenes
 
-The scene in AlpaSim is a NuRec reconstruction of a real-world driving log.
+Scenes in AlpaSim are USDZ artifacts built from real-world driving logs. The default NuRec renderer
+and the OmniDreams video-model renderer both use these artifacts; OmniDreams additionally conditions
+on ClipGT data packaged in the USDZ, including recorded first-frame JPEGs, camera calibration, and
+HD map data.
 
-Publicly available NuRec scenes are stored on
+Publicly available scene artifacts are stored on
 [Hugging Face](https://huggingface.co/datasets/nvidia/PhysicalAI-Autonomous-Vehicles-NuRec/tree/26.01/sample_set/26.01_release)
 and, once downloaded, are placed under `data/nre-artifacts/all-usdzs`. The scenes are identified by
 their uuid, rather than their filenames, to prevent versioning issues. The list of currently


### PR DESCRIPTION
## Summary
- Sync latest changes from internal GitLab repository
- Last synced commit: `e211fd54` - Improve OmniDreams renderer docs visibility
- Includes 1 commit(s) from GitLab

## Excluded from sync
- `plugins/internal/` - Internal-only plugin and CI/CD scripts
- `.gitlab-ci.yml` - GitLab-specific CI configuration

## Test plan
- [x] Script completed cherry-pick and created a single squashed commit
- [x] Verify CI passes on GitHub
- [x] Review changes in PR
- [x] Merge to main