### PR TITLE
Fix: Build gsplat's CUDA kernels for sm_90 + PTX

### DIFF
--- a/src/wizard/configs/e2e_challenge_nuplan_common/base.yaml
+++ b/src/wizard/configs/e2e_challenge_nuplan_common/base.yaml
@@ -26,7 +26,7 @@ services:
     environments:
       - UV_LINK_MODE=copy
       # Build gsplat's CUDA kernels for sm_90 + PTX
-      - TORCH_CUDA_ARCH_LIST=9.0+PTX
+      - "TORCH_CUDA_ARCH_LIST=8.9;9.0+PTX"
     command:
       - "uv run alpasim-mtgs-server"
       - "--user-config=/mnt/log_dir/{runtime_config_name}"

--- a/src/wizard/configs/e2e_challenge_nuplan_common/base.yaml
+++ b/src/wizard/configs/e2e_challenge_nuplan_common/base.yaml
@@ -25,6 +25,8 @@ services:
       - "${repo-relative:'plugins'}:/repo/plugins"
     environments:
       - UV_LINK_MODE=copy
+      # Build gsplat's CUDA kernels for sm_90 + PTX
+      - TORCH_CUDA_ARCH_LIST=9.0+PTX
     command:
       - "uv run alpasim-mtgs-server"
       - "--user-config=/mnt/log_dir/{runtime_config_name}"


### PR DESCRIPTION
**Problem:** Setting up of the nuplan e2e-challenge starter kit doesn't work for more recent GPU architectures given the cuda versions in the container. 

**Solution:** Build gsplat's CUDA kernels for sm_90 + PTX so the modern GPUs JIT-compiles them at load time.