### PR TITLE
runtime: derive fallback dynamic states from the ground-truth trajectory

### DIFF
--- a/src/driver/src/alpasim_driver/main.py
+++ b/src/driver/src/alpasim_driver/main.py
@@ -635,10 +635,15 @@ class EgoDriverService(EgodriverServiceServicer):
             leftover.result.cancel()
 
     def _get_speed_and_acceleration(self, session: Session) -> tuple[float, float]:
-        """Extract speed and acceleration from session's dynamic state.
+        """Extract speed and acceleration from the most recent dynamic state.
 
-        Falls back to finite differences from ego positions if dynamic state
-        reports zero speed and acceleration.
+        Values are used as the runtime reports them; there is no local
+        finite-difference fallback here. (An earlier version of this docstring
+        promised one that was never implemented. The main source of zero
+        readings while the vehicle was moving -- the forced-GT window, where the
+        controller service substituted ground-truth poses paired with all-zero
+        dynamic states -- is fixed in the controller service by deriving the
+        fallback dynamics from the same trajectory as the poses.)
 
         Args:
             session: Session containing dynamic state history.

--- a/src/runtime/alpasim_runtime/services/controller_service.py
+++ b/src/runtime/alpasim_runtime/services/controller_service.py
@@ -42,6 +42,46 @@ class PropagatedPosesAtTime:
     dynamic_state_estimated: DynamicState  # The estimated dynamic state
 
 
+# Half-window for differentiating the fallback trajectory. Wide enough to smooth
+# recorded-pose jitter, narrow enough to track speed changes across a force-GT window.
+_FALLBACK_DYNAMICS_WINDOW_US = 100_000
+
+
+def _fallback_dynamic_state(
+    fallback_trajectory_local_to_rig: Trajectory, at_us: int
+) -> DynamicState:
+    """Dynamic state derived from the fallback (ground-truth) trajectory at ``at_us``.
+
+    The fallback paths below (force-GT, skip mode, interpolated intermediates) used
+    to pair real, moving poses with a default-constructed -- all-zero --
+    ``DynamicState``. Downstream, those zeros flow through
+    ``ego_trajectory_estimate`` into the driver's egomotion observations, so for the
+    whole ``force_gt_duration_us`` window the driver saw poses advancing at driving
+    speed while the dynamic state reported a stopped vehicle. Deriving velocity from
+    the same trajectory the poses are interpolated from keeps the two consistent.
+
+    ``interpolate_delta(t0, t1)`` returns ``pose(t0).inverse() @ pose(t1)``, i.e. the
+    motion expressed in the rig frame at ``t0`` -- the frame dynamic states are
+    reported in. Linear velocity and yaw rate are populated; accelerations are left
+    at zero, matching how context dynamics are seeded in ``event_loop.py`` (double-
+    differencing recorded poses would mostly amplify noise).
+    """
+    timestamps_us = fallback_trajectory_local_to_rig.timestamps_us
+    t0 = max(int(timestamps_us[0]), at_us - _FALLBACK_DYNAMICS_WINDOW_US)
+    t1 = min(int(timestamps_us[-1]), at_us + _FALLBACK_DYNAMICS_WINDOW_US)
+    if t1 <= t0:
+        return DynamicState()
+    delta = fallback_trajectory_local_to_rig.interpolate_delta(t0, t1)
+    dt_s = (t1 - t0) * 1e-6
+    velocity = delta.vec3.astype(np.float64) / dt_s
+    return DynamicState(
+        linear_velocity=Vec3(
+            x=float(velocity[0]), y=float(velocity[1]), z=float(velocity[2])
+        ),
+        angular_velocity=Vec3(x=0.0, y=0.0, z=float(delta.yaw()) / dt_s),
+    )
+
+
 class ControllerService(ServiceBase[VDCServiceStub]):
     """
     Controller service implementation that handles both real and skip modes.
@@ -177,8 +217,12 @@ class ControllerService(ServiceBase[VDCServiceStub]):
                     timestamp_us=t,
                     pose_local_to_rig=pose,
                     pose_local_to_rig_estimate=pose,
-                    dynamic_state=DynamicState(),
-                    dynamic_state_estimated=DynamicState(),
+                    dynamic_state=_fallback_dynamic_state(
+                        fallback_trajectory_local_to_rig, t
+                    ),
+                    dynamic_state_estimated=_fallback_dynamic_state(
+                        fallback_trajectory_local_to_rig, t
+                    ),
                 )
                 for t, pose in zip(expected_intermediate_timestamps, poses, strict=True)
             ]
@@ -239,8 +283,12 @@ class ControllerService(ServiceBase[VDCServiceStub]):
                     timestamp_us=future_us,
                     pose_local_to_rig=fallback_pose_local_to_rig,
                     pose_local_to_rig_estimate=fallback_pose_local_to_rig,
-                    dynamic_state=DynamicState(),
-                    dynamic_state_estimated=DynamicState(),
+                    dynamic_state=_fallback_dynamic_state(
+                        fallback_trajectory_local_to_rig, future_us
+                    ),
+                    dynamic_state_estimated=_fallback_dynamic_state(
+                        fallback_trajectory_local_to_rig, future_us
+                    ),
                 )
             ]
             return self._ensure_intermediates(
@@ -286,8 +334,12 @@ class ControllerService(ServiceBase[VDCServiceStub]):
                     timestamp_us=future_us,
                     pose_local_to_rig=fallback_pose_local_to_rig,
                     pose_local_to_rig_estimate=fallback_pose_local_to_rig,
-                    dynamic_state=DynamicState(),
-                    dynamic_state_estimated=DynamicState(),
+                    dynamic_state=_fallback_dynamic_state(
+                        fallback_trajectory_local_to_rig, future_us
+                    ),
+                    dynamic_state_estimated=_fallback_dynamic_state(
+                        fallback_trajectory_local_to_rig, future_us
+                    ),
                 )
             ]
         elif response.states:

--- a/src/runtime/tests/services/test_controller_api.py
+++ b/src/runtime/tests/services/test_controller_api.py
@@ -138,3 +138,76 @@ async def test_skip_mode_generates_intermediates(default_args):
         for state in propagated_states[:-1]:
             x = state.pose_local_to_rig.vec3[0]
             assert 1.0 < x < 5.0, f"Intermediate x={x} should be between 1.0 and 5.0"
+
+
+async def test_skip_mode_reports_fallback_dynamics_not_zeros(default_args):
+    """The fallback paths used to pair moving poses with a default-constructed
+    (all-zero) DynamicState, so during the forced-GT window the driver saw poses
+    advancing at driving speed while the dynamic state said the vehicle was
+    stopped. The dynamics must come from the same trajectory as the poses."""
+    mock_broadcaster = AsyncMock(spec=MessageBroadcaster)
+    controller = ControllerService(address="localhost:50051", skip=True)
+
+    async with controller.rollout_session(
+        uuid=default_args["session_uuid"], broadcaster=mock_broadcaster
+    ):
+        args = default_args.copy()
+        del args["session_uuid"]
+        propagated_states = await controller.run_controller_and_vehicle(**args)
+
+    # The fallback trajectory moves x: 1.0 -> 5.0 over 100 ms: 40 m/s, no rotation.
+    for state in propagated_states:
+        for dynamic_state in (state.dynamic_state, state.dynamic_state_estimated):
+            assert dynamic_state.linear_velocity.x == pytest.approx(40.0, rel=1e-3)
+            assert dynamic_state.linear_velocity.y == pytest.approx(0.0, abs=1e-6)
+            assert dynamic_state.angular_velocity.z == pytest.approx(0.0, abs=1e-6)
+
+
+async def test_intermediates_report_fallback_dynamics_not_zeros(default_args):
+    """Interpolated intermediate states must carry fallback-derived dynamics too."""
+    mock_broadcaster = AsyncMock(spec=MessageBroadcaster)
+    controller = ControllerService(address="localhost:50051", skip=True)
+
+    async with controller.rollout_session(
+        uuid=default_args["session_uuid"], broadcaster=mock_broadcaster
+    ):
+        args = default_args.copy()
+        del args["session_uuid"]
+        args["pose_reporting_interval_us"] = 25000
+        propagated_states = await controller.run_controller_and_vehicle(**args)
+
+    assert len(propagated_states) > 1
+    for state in propagated_states:
+        assert state.dynamic_state_estimated.linear_velocity.x == pytest.approx(
+            40.0, rel=1e-3
+        )
+
+
+async def test_force_gt_reports_fallback_dynamics_not_zeros(
+    default_args, monkeypatch
+):
+    """The force-GT branch discards the controller response and substitutes GT
+    poses; the dynamic states it pairs with them must be derived from the same
+    trajectory, not left at zero."""
+    from alpasim_grpc.v0.controller_pb2 import RunControllerAndVehicleModelResponse
+    from alpasim_runtime.services import controller_service as controller_service_module
+
+    async def fake_rpc(*_args, **_kwargs):
+        return RunControllerAndVehicleModelResponse()
+
+    monkeypatch.setattr(controller_service_module, "profiled_rpc_call", fake_rpc)
+    mock_broadcaster = AsyncMock(spec=MessageBroadcaster)
+    controller = ControllerService(address="localhost:50051", skip=False)
+
+    async with controller.rollout_session(
+        uuid=default_args["session_uuid"], broadcaster=mock_broadcaster
+    ):
+        args = default_args.copy()
+        del args["session_uuid"]
+        args["force_gt"] = True
+        propagated_states = await controller.run_controller_and_vehicle(**args)
+
+    final = propagated_states[-1]
+    assert final.pose_local_to_rig.vec3[0] == pytest.approx(5.0, abs=1e-4)
+    for dynamic_state in (final.dynamic_state, final.dynamic_state_estimated):
+        assert dynamic_state.linear_velocity.x == pytest.approx(40.0, rel=1e-3)


### PR DESCRIPTION
The zero speed/acceleration readings come from the runtime, not the driver.

`controller_service.py`'s force-GT branch replaces the controller response with poses interpolated from the fallback (ground-truth) trajectory, but pairs them with a default-constructed `DynamicState`, i.e. all zeros:

```python
# When force_gt, ignore the controller response and populate from the
# fallback (ground-truth) trajectory so downstream always sees GT poses.
if force_gt:
    ...
    dynamic_state=DynamicState(),
    dynamic_state_estimated=DynamicState(),
```

The skip-mode branch and the interpolated-intermediates backfill in the same file do the same thing. Those zeros then flow through `ego_trajectory_estimate` and `interpolate_dynamics` into the driver's egomotion observations, so for the whole `force_gt_duration_us` window the driver sees poses advancing at driving speed while the dynamic state says the vehicle is stopped.

Measured at the driver on `main` (`1e801ca`), with a video-model chunking preset (`force_gt_duration_us = 2_033_313`, `control_timestep_us = 266_664`):

| frame | `DynamicState` speed | pose-derived speed |
| --- | --- | --- |
| 0 | 5.158 | 5.158 |
| 1–7 | **0.0** | 10.9 – 11.8 |
| 8 | 11.919 | 11.919 |

Frames 1 through 7 are exactly the control steps inside the force-GT window; frame 8 is the first one outside it, and the zeros never recur. With the default `force_gt_duration_us = 500_000` the window is shorter, but it's present in every rollout. Since `skip_driver_during_force_gt` defaults to `False`, the driver is queried throughout that window by default, so a history-based policy builds its context on those contradictory observations during precisely the period meant to warm it up on realistic ones.

## Fix

Derive the fallback dynamic state from the same trajectory the poses come from. `Trajectory.interpolate_delta(t0, t1)` returns `pose(t0).inverse() @ pose(t1)`, which is the motion expressed in the rig frame at `t0`, and that's the frame dynamic states are reported in, so linear velocity and yaw rate fall out of a ±100 ms window around the query time. Accelerations stay zero, matching how context dynamics are seeded in `event_loop.py`; double-differencing recorded poses would mostly amplify noise.

All three zero sites (force-GT, skip mode, intermediates backfill) go through one helper. The driver's `_get_speed_and_acceleration` docstring promised a finite-difference fallback that was never implemented, so it's corrected to describe what the code actually does.

## Tests

Three tests in `src/runtime/tests/services/test_controller_api.py` drive `run_controller_and_vehicle` through the skip, intermediates and force-GT paths using the existing fixture's 40 m/s fallback trajectory, and assert the returned dynamics are real.

On unpatched `main` all three fail in about 0.05 s, CPU only, with no GPU, renderer or scene data involved. With the change, `tests/services/` is 22/22 and the full runtime suite is 346 passed, with one pre-existing failure (`test_route_generator_map`) that fails identically without this patch.

This replaces the driver-side fallback the PR originally proposed; the review comments above refer to that earlier diff.
