### PR TITLE
docker: fix the ARM64 image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ FROM nvcr.io/nvidia/pytorch:25.08-py3 AS base-arm64
 FROM nvcr.io/nvidia/k8s/dcgm-exporter:4.4.1-4.6.0-ubuntu22.04@sha256:b7a4241c608253aa829041cc3575ea57082491251a4a626bcdddc68eaf9a3101 AS dcgm-exporter
 ARG TARGETARCH
 FROM base-${TARGETARCH}
+ARG TARGETARCH
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 COPY --from=dcgm-exporter /usr/bin/dcgm-exporter /usr/bin/dcgm-exporter
@@ -22,6 +23,12 @@ RUN printf '%s\n' \
     >> /etc/dcgm-exporter/default-counters.csv
 
 ARG DEBIAN_FRONTEND=noninteractive
+RUN if [ "${TARGETARCH}" = "arm64" ]; then \
+      . /etc/os-release && \
+      ubuntu_repo="ubuntu$(echo "${VERSION_ID}" | tr -d '.')" && \
+      curl -fsSL -o /tmp/cuda-keyring.deb "https://developer.download.nvidia.com/compute/cuda/repos/${ubuntu_repo}/sbsa/cuda-keyring_1.1-1_all.deb" && \
+      dpkg -i /tmp/cuda-keyring.deb && rm -f /tmp/cuda-keyring.deb; \
+    fi
 RUN apt-get update && apt-get install -y \
     git \
     ffmpeg \
@@ -55,9 +62,26 @@ RUN uv run compile-protos --no-sync
 
 WORKDIR /repo
 
+# The arm64 branch installs its package subset explicitly rather than selecting an
+# extra through `uv sync`: syncing through the project resolution yields a +cpu
+# torch build on aarch64, while the direct install resolves an aarch64 CUDA build
+# (measured on GB10: 2.8.0+cpu via sync vs 2.13.0+cu130 with CUDA available).
 RUN --mount=type=secret,id=netrc,target=/root/.netrc \
     --mount=type=cache,target=/root/.cache/uv \
-    sh -c 'if [ -f /root/.netrc ]; then export NETRC=/root/.netrc; fi && uv sync --extra all --extra recipes'
+    sh -c '\
+      if [ -f /root/.netrc ]; then export NETRC=/root/.netrc; fi && \
+      if [ "${TARGETARCH}" = "arm64" ]; then \
+        uv pip install --python /repo/.venv/bin/python \
+          -e /repo/src/plugins \
+          -e /repo/src/grpc \
+          -e /repo/src/utils \
+          -e /repo/src/controller \
+          -e /repo/src/eval \
+          -e /repo/src/runtime \
+          -e /repo/src/physics; \
+      else \
+        uv sync --extra all --extra recipes; \
+      fi'
 
 ARG PYTORCH_VERSION=2.8.0+cu128
 ARG TORCH_CLUSTER_VERSION=1.6.3
@@ -66,12 +90,16 @@ ARG TORCH_SPARSE_VERSION=0.6.18
 
 # Install PyG compiled extensions (torch-cluster, torch-scatter, torch-sparse)
 # from pre-built wheels matching the installed torch + CUDA versions.
-RUN PYG_WHEEL_URL="https://data.pyg.org/whl/torch-${PYTORCH_VERSION}.html" && \
-    uv pip install \
-        "torch-cluster==${TORCH_CLUSTER_VERSION}" \
-        "torch-scatter==${TORCH_SCATTER_VERSION}" \
-        "torch-sparse==${TORCH_SPARSE_VERSION}" \
-        -f "$PYG_WHEEL_URL"
+# Only alpasim-trafficsim needs these, and it is excluded from the arm64 package set
+# above; the wheel index is also pinned to an x86 CUDA build.
+RUN if [ "${TARGETARCH}" != "arm64" ]; then \
+      PYG_WHEEL_URL="https://data.pyg.org/whl/torch-${PYTORCH_VERSION}.html" && \
+      uv pip install \
+          "torch-cluster==${TORCH_CLUSTER_VERSION}" \
+          "torch-scatter==${TORCH_SCATTER_VERSION}" \
+          "torch-sparse==${TORCH_SPARSE_VERSION}" \
+          -f "$PYG_WHEEL_URL"; \
+    fi
 
 ENV UV_CACHE_DIR=/tmp/uv-cache
 ENV UV_NO_SYNC=1


### PR DESCRIPTION
The Dockerfile already picks an ARM64 base (`FROM nvcr.io/nvidia/pytorch:25.08-py3 AS base-arm64`), but the build fails further down, so that path is currently unreachable. This finishes it.

The target is DGX Spark (GB10). With these changes the runtime, controller, physics and trafficsim services build and run natively there, and we've run complete closed-loop rollouts on that hardware using the video-model renderer (`runtime.renderer.kind=video_model`, OmniDreams via FlashDreams), which suits GB10's unified memory. The one component still x86-only is the prebuilt NuRec/sensorsim image, which that renderer path doesn't use.

## What breaks on aarch64

Four separate failures past base-image selection. All four fixes key off `TARGETARCH`, so the x86_64 path is untouched.

**1. `ARG TARGETARCH` isn't in scope in the final stage.** BuildKit's builtin platform args are always available to `FROM` lines, so `FROM base-${TARGETARCH}` resolves with no `ARG` at all. But an `ARG` after a `FROM` belongs to that stage, and only stages derived from it inherit the value. The existing declaration sits in the dcgm-exporter stage, which the final stage doesn't derive from, so any arch conditional there compares against the empty string on every architecture. It shows up as a step finishing suspiciously fast, not as an error, which is why static reading misses it. I checked this with minimal repro Dockerfiles covering global, ancestor-stage, non-ancestor-stage and no-ARG placements.

**2. No CUDA apt repo on the ARM64 base.** `datacenter-gpu-manager-4-cuda12` comes from it and `nvcr.io/nvidia/pytorch` ships only plain Ubuntu ports repos, so `apt-get install` fails before anything else runs. The repo path is derived from the base image's own `/etc/os-release`, so it follows the base image across Ubuntu releases instead of pinning one.

**3. `--extra all --extra recipes` can't resolve.** `alpasim-tools` pulls PyQt5 (no aarch64 wheel), `alpasim_driver`/`alpasim_plugins` pull x86-only packages like `tensordict` through the learned-driver models, `alpasim_wizard` runs on the host, and `alpasim-trafficsim` pulls `torch_geometric`. The arm64 branch installs an explicit subset.

  Why an explicit list and not a declared extra consumed via `uv sync --extra <subset>`: measured on GB10, going through the project resolution installs a `+cpu` torch on aarch64 (`2.8.0+cpu`, `torch.version.cuda == None`), while the direct install resolves `2.13.0+cu130` with CUDA available. Until torch sourcing handles aarch64, the sync path quietly produces a CUDA-less runtime image.

**4. PyG extensions are x86-pinned.** That step's wheel index points at `2.8.0+cu128` and publishes nothing for aarch64. Only `alpasim-trafficsim` needs those extensions and it's excluded above, so on arm64 they aren't needed at all.

## Verification

Full `docker build` on GB10 hardware against current `main`:

* Succeeds end to end, 33.1 GB image, zero errors. The log shows the conditionals expanding as `if [ "arm64" = "arm64" ]` and `if [ "arm64" != "arm64" ]`, i.e. `TARGETARCH` resolving instead of empty (the failure mode from item 1).
* Inside the image, all seven installed packages import on aarch64 (`alpasim_controller`, `alpasim_runtime`, `alpasim_physics`, `alpasim_grpc`, `alpasim_utils`, `alpasim_plugins`, and `alpasim_eval` via its top-level module `eval`), `torch 2.13.0+cu130`, `torch.cuda.is_available()` true with `--gpus all`.
* The excluded packages really are absent: `import PyQt5` and `import tensordict` both raise `ModuleNotFoundError`.

Item 1 is arguably a bug independent of ARM support, since it makes any arch conditional in the final stage compare against an empty string. Happy to split it out if the platform scope here needs more discussion.

Rebased onto current `main` after the August sync rewrote the Dockerfile, which is what the earlier conflict was. Single commit, Dockerfile only.
