### PR TITLE
Fix: docs/VIDEO_MODEL.md 

### DIFF
--- a/docs/VIDEO_MODEL.md
+++ b/docs/VIDEO_MODEL.md
@@ -118,7 +118,14 @@ uv run --project src/wizard alpasim_wizard \
 The preset uses `services.renderer.image=flashdreams-alpasim:local`,
 `external_image=true`, and `pull_policy=never`, so Docker Compose uses the local image tag instead of trying to pull from a registry. The wizard starts a `renderer-0` container and connects Alpasim services to it.
 
-The managed container mounts persistent host caches for Hugging Face, Torch, and FlashDreams. Override these host paths if needed:
+The managed container mounts persistent host caches for Hugging Face, Torch, and FlashDreams.
+
+Ensure the cache folders exist on host:
+```bash
+mkdir -p ~/.cache/huggingface ~/.cache/torch ~/.cache/flashdreams
+```
+
+Alternatively, override these host paths if needed:
 
 ```bash
 defines.hf_cache=/path/to/hf-cache \

--- a/docs/VIDEO_MODEL.md
+++ b/docs/VIDEO_MODEL.md
@@ -70,7 +70,7 @@ FlashDreams publishes `Dockerfile`s but not pre-built images. We need to build t
 
 ```bash
 cd ../flashdreams
-docker build -t flashdreams-base:local -f docker/Dockerfile .
+docker build -t flashdreams:local -f docker/Dockerfile .
 ```
 
 2. Then build the Alpasim-ready FlashDreams image. This bakes the workspace source


### PR DESCRIPTION
Hi,

I am proposing two minor fixes to the docs/VIDEO_MODEL.md on onboarding new users to video (world) models.

### 1. Flashdreams local image tag mismatch

**Problem:**  
The current documentation instructs users to build the base image using the tag `flashdreams-base:local`:

```bash
docker build -t flashdreams-base:local -f docker/Dockerfile .
```

However, [`docker/Dockerfile.alpasim`](https://github.com/NVIDIA/flashdreams/blob/44e52c70444a0ea63dc746cdf1723e4caed37ced/docker/Dockerfile.alpasim#L6) expects `flashdreams:local` as its base image. This causes the subsequent build command to fail because the expected base tag is missing:

```bash
docker build -t flashdreams-alpasim:local -f docker/Dockerfile.alpasim .
```

**Fix:**  
I updated the documentation command to tag the base image as `flashdreams:local`:

```bash
docker build -t flashdreams:local -f docker/Dockerfile .
```


### 2. Ensure cache directories existing on host
**Problem:**  

Managed flashdreams container mounts cache directories in the `docker-compose.yml` deployment like:
```
  renderer-0:
    networks:
      - microservices_network
    volumes:
      - /home/ubuntu/.cache/huggingface:/root/.cache/huggingface
      - /home/ubuntu/.cache/torch:/root/.cache/torch
      - /home/ubuntu/.cache/flashdreams:/root/.cache/flashdreams
```

However if they don't exist on host, they might not be created by Docker automatically and crash the deployment. 

**Fix:**  
Added an explicit `mkdir -p` step to ensure the host cache directories exist prior to running the AlpaSim wizard:

```bash
mkdir -p ~/.cache/huggingface ~/.cache/torch ~/.cache/flashdreams
```

