### PR TITLE
Fix linear MPC for initial speeds above limit

### DIFF
--- a/src/controller/alpasim_controller/mpc_impl/linear_mpc.py
+++ b/src/controller/alpasim_controller/mpc_impl/linear_mpc.py
@@ -53,6 +53,7 @@ class LinearMPC(MPCController):
     OSQP_EPS_REL = 1e-4
     OSQP_MAX_ITER = 500
     QP_REGULARIZATION = 1e-6
+    OVERSPEED_RECOVERY_ACCEL = -1.0
 
     def __init__(
         self,
@@ -417,7 +418,20 @@ class LinearMPC(MPCController):
 
         x_pred_from_x0 = x_pred_free[constrained_rows]
         l_state = np.tile(self._x_min_constrained, N) - x_pred_from_x0
-        u_state = np.tile(self._x_max_constrained, N) - x_pred_from_x0
+        x_max = np.tile(self._x_max_constrained, N)
+        vx_constraint_index = self._constrained_state_indices.index(self.IVX)
+        vx_rows = np.arange(
+            vx_constraint_index,
+            len(x_max),
+            len(self._constrained_state_indices),
+        )
+        if x0[self.IVX] > self._x_max_constrained[vx_constraint_index]:
+            recovery_controls = np.zeros(N * nu)
+            recovery_controls[1::nu] = self.OVERSPEED_RECOVERY_ACCEL
+            recovery_states = x_pred_free + S_u @ recovery_controls
+            recovery_vx = recovery_states[constrained_rows][vx_rows]
+            x_max[vx_rows] = np.maximum(x_max[vx_rows], recovery_vx)
+        u_state = x_max - x_pred_from_x0
 
         l_ineq = np.concatenate([l_input, l_state])
         u_ineq = np.concatenate([u_input, u_state])

--- a/src/controller/tests/mpc_impl/test_linear_mpc.py
+++ b/src/controller/tests/mpc_impl/test_linear_mpc.py
@@ -78,6 +78,27 @@ class TestLinearMPCComputeControl:
         # Should command negative steering to correct positive y error
         assert output.control[0] < 0
 
+    def test_compute_control_above_speed_constraint(self):
+        """A high initial speed should brake while retaining lateral control."""
+        controller = LinearMPC()
+        velocity = 36.1
+        trajectory = _create_simple_trajectory(velocity=velocity)
+        state = np.zeros(8)
+        state[controller.IY] = 1.0
+        state[controller.IVX] = velocity
+
+        output = controller.compute_control(
+            ControllerInput(
+                state=state,
+                reference_trajectory=trajectory,
+                timestamp_us=0,
+            )
+        )
+
+        assert output.status in ("solved", "solved_inaccurate")
+        assert output.control[0] < 0
+        assert output.control[1] < 0
+
     def test_control_is_continuous_at_kinematic_model_threshold(self):
         """Crossing the speed threshold must not double the steering contribution."""
         controller = LinearMPC()


### PR DESCRIPTION
Closes #140

**Root cause:** The fixed 35 m/s state bound makes the QP infeasible when a rollout starts above it.

**Fix:** While overspeeding, use the vehicle model's response to a -1 m/s² acceleration command as a reachable, descending `vx` bound. The QP must decelerate but remains free to optimize steering. Normal-speed constraints are unchanged.

**Test:** Added a 36.1 m/s lateral-error regression that asserts a solved QP with both braking and steering; all 11 linear MPC tests pass.