### PR TITLE
controller: increase linear MPC speed bound to 40 m/s

### DIFF
--- a/src/controller/alpasim_controller/mpc_impl/linear_mpc.py
+++ b/src/controller/alpasim_controller/mpc_impl/linear_mpc.py
@@ -116,7 +116,7 @@ class LinearMPC(MPCController):
         self._x_max_constrained = np.array(
             [
                 math.pi / 2,  # yaw (rad)
-                35.0,  # vx (m/s) - ~125 km/h
+                40.0,  # vx (m/s) - ~145 km/h
                 math.pi / 4,  # steering (rad)
                 6.0,  # accel (m/s²) - acceleration limit
             ]

--- a/src/controller/tests/mpc_impl/test_linear_mpc.py
+++ b/src/controller/tests/mpc_impl/test_linear_mpc.py
@@ -4,6 +4,7 @@
 """Unit tests for LinearMPC controller."""
 
 import numpy as np
+import pytest
 from alpasim_controller.mpc_controller import ControllerInput, MPCGains
 from alpasim_controller.mpc_impl import LinearMPC
 from alpasim_controller.vehicle_model import VehicleModel
@@ -57,15 +58,16 @@ class TestLinearMPCComputeControl:
         assert output.solve_time_ms > 0
         assert output.status in ("solved", "solved_inaccurate")
 
-    def test_compute_control_with_lateral_error(self):
+    @pytest.mark.parametrize("velocity", [10.0, 40.0])
+    def test_compute_control_with_lateral_error(self, velocity):
         """Controller should command steering to correct lateral error."""
         controller = LinearMPC()
-        trajectory = _create_simple_trajectory(velocity=10.0)
+        trajectory = _create_simple_trajectory(velocity=velocity)
 
         # State with lateral offset
         state = np.zeros(8)
         state[1] = 1.0  # y = 1m offset
-        state[3] = 10.0  # vx
+        state[3] = velocity  # vx
 
         input = ControllerInput(
             state=state,


### PR DESCRIPTION
Closes #140

Raises the linear MPC longitudinal-speed bound from 35 to 40 m/s. Across 180,985 controller states from our public_2601 evaluation, the maximum observed speed was 36.204 m/s, with none at or above 40 m/s.

Extends the existing lateral-control test to verify that the QP remains feasible and steering stays active at 40 m/s.

Test: 11 linear MPC tests passed.