### PR TITLE
docs: build the FlashDreams base under the tag Dockerfile.alpasim expects

### DIFF
--- a/docs/VIDEO_MODEL.md
+++ b/docs/VIDEO_MODEL.md
@@ -70,7 +70,7 @@ FlashDreams publishes `Dockerfile`s but not pre-built images. We need to build t
 
 ```bash
 cd ../flashdreams
-docker build -t flashdreams-base:local -f docker/Dockerfile .
+docker build -t flashdreams:local -f docker/Dockerfile .
 ```
 
 2. Then build the Alpasim-ready FlashDreams image. This bakes the workspace source


### PR DESCRIPTION
Following the FlashDreams build steps in `docs/VIDEO_MODEL.md` verbatim fails at step 2. Step 1 tags the base image `flashdreams-base:local`, but FlashDreams' `docker/Dockerfile.alpasim` declares `ARG FLASHDREAMS_BASE_IMAGE=flashdreams:local`, so the second build stops with a nonexistent-image error.

FlashDreams' own `docker/README.md` builds under `flashdreams:local`, and that ARG default has never had another value in its history, so aligning the tag here is what makes the two documents agree.

If you already built the base under the old tag, `--build-arg FLASHDREAMS_BASE_IMAGE=flashdreams-base:local` on step 2 works without rebuilding.

Hit this while setting up the video-model renderer; checked against FlashDreams `main` (`4f776ab`).
