### PR TITLE
driver: construct real CameraFrame instances instead of plain tuples

### DIFF
--- a/src/driver/src/alpasim_driver/main.py
+++ b/src/driver/src/alpasim_driver/main.py
@@ -60,6 +60,7 @@ from .frame_cache import FrameCache
 from .models import DriveCommand
 from .models.base import (
     BaseTrajectoryModel,
+    CameraFrame,
     CameraImages,
     ModelInputValidationError,
     ModelPrediction,
@@ -672,7 +673,9 @@ class EgoDriverService(EgodriverServiceServicer):
         for cam_id in self._model.camera_ids:
             frame_cache = session.frame_caches[cam_id]
             entries = frame_cache.latest_frame_entries(self._context_length)
-            camera_images[cam_id] = [(e.timestamp_us, e.image) for e in entries]
+            camera_images[cam_id] = [
+                CameraFrame(timestamp_us=e.timestamp_us, image=e.image) for e in entries
+            ]
 
         return camera_images
 


### PR DESCRIPTION
`models/base.py` declares what a model receives:

```python
class CameraFrame(NamedTuple):
    timestamp_us: int
    image: np.ndarray | torch.Tensor

CameraImages = dict[str, list[CameraFrame]]
```

`EgoDriverService._prepare_camera_images` is the only place those values get built, and it emits plain tuples. `CameraFrame` isn't referenced anywhere else in `main.py` outside a docstring:

```python
camera_images[cam_id] = [(e.timestamp_us, e.image) for e in entries]
```

So code written against the declared interface gets an object that doesn't satisfy it:

```python
frame = camera_images["front"][-1]
isinstance(frame, CameraFrame)   # False
frame.timestamp_us               # AttributeError: 'tuple' object has no attribute 'timestamp_us'
```

This patch makes the emitted objects satisfy the declared type.

No in-tree behaviour changes. Every built-in model and the transfuser plugin do `for ts, img in frames`, and `CameraFrame` is a `NamedTuple`, so positional unpacking keeps working. What changes is that `isinstance(frame, CameraFrame)` becomes True, as the annotation already claims.

The mismatch has also needed compatibility handling downstream: AlpaBridge registers through the `alpasim.models` entry-point group and currently accepts both representations ([1](https://github.com/amtellezfernandez/AlpaBridge/blob/17c3bee/src/alpabridge/simulator/alpasim_contract.py#L389-L391), [2](https://github.com/amtellezfernandez/AlpaBridge/blob/17c3bee/src/alpabridge/simulator/alpasim_contract.py#L408-L410)).

Four lines at one site. The other way to resolve it is to weaken the annotation to plain tuples, which drops a documented guarantee.
