### PR TITLE
runtime: make rollout seeds selectable and reproducible via RolloutSpec

### DIFF
--- a/src/grpc/alpasim_grpc/v0/runtime.proto
+++ b/src/grpc/alpasim_grpc/v0/runtime.proto
@@ -25,6 +25,10 @@ message RolloutSpec {
     // Microseconds to skip from the start of the recording; the rollout begins
     // that far into the clip. 0 (default) starts at the clip's first frame.
     fixed64 start_time_offset_us = 4;
+    // Base random seed for this spec's rollouts: rollout k uses random_seed + k as
+    // its session seed, so a specific rollout can be reproduced on its own.
+    // 0 (default) keeps today's behaviour: the runtime picks a random seed per session.
+    fixed64 random_seed = 5;
 }
 
 message SimulationRequest {

--- a/src/runtime/alpasim_runtime/daemon/engine.py
+++ b/src/runtime/alpasim_runtime/daemon/engine.py
@@ -207,6 +207,9 @@ def build_pending_jobs_from_request(
                     rollout_spec_index=spec_index,
                     session_uuid=session_uuids[rollout_idx] if session_uuids else "",
                     start_time_offset_us=spec.start_time_offset_us,
+                    session_seed=(
+                        spec.random_seed + rollout_idx if spec.random_seed else 0
+                    ),
                 )
             )
     return jobs

--- a/src/runtime/alpasim_runtime/daemon/scheduler.py
+++ b/src/runtime/alpasim_runtime/daemon/scheduler.py
@@ -813,6 +813,7 @@ class DaemonScheduler:
                 scheduler_wait_seconds=max(0.0, monotonic() - job.enqueued_at),
                 session_uuid=job.session_uuid,
                 start_time_offset_us=job.start_time_offset_us,
+                session_seed=job.session_seed,
             )
             self._runtime.submit_assigned_job(assigned)
             self._in_flight[assigned.job_id] = _InFlightEntry(

--- a/src/runtime/alpasim_runtime/event_loop.py
+++ b/src/runtime/alpasim_runtime/event_loop.py
@@ -571,6 +571,7 @@ class EventBasedRollout:
                     session_config=DriverSessionConfig(
                         sensorsim_cameras=available_camera_protos,
                         scene_id=self.unbound.scene_id,
+                        random_seed=self.unbound.session_seed or None,
                     ),
                 )
             )
@@ -590,6 +591,7 @@ class EventBasedRollout:
                         start_timestamp_us=self.unbound.egomotion_context_start_us,
                         force_gt_duration_us=self.unbound.force_gt_duration_us,
                         control_timestep_us=self.unbound.control_timestep_us,
+                        random_seed=self.unbound.session_seed or None,
                     ),
                 )
             )

--- a/src/runtime/alpasim_runtime/services/driver_service.py
+++ b/src/runtime/alpasim_runtime/services/driver_service.py
@@ -72,7 +72,11 @@ class DriverService(ServiceBase[EgodriverServiceStub]):
 
         request = DriveSessionRequest(
             session_uuid=session_info.uuid,
-            random_seed=random.randint(0, 2**32 - 1),
+            random_seed=(
+                cfg.random_seed
+                if cfg.random_seed is not None
+                else random.randint(0, 2**32 - 1)
+            ),
             debug_info=DriveSessionRequest.DebugInfo(scene_id=scene_id),
             rollout_spec=rollout_spec,
         )

--- a/src/runtime/alpasim_runtime/services/session_configs.py
+++ b/src/runtime/alpasim_runtime/services/session_configs.py
@@ -26,6 +26,8 @@ class DriverSessionConfig:
 
     sensorsim_cameras: list[AvailableCamerasReturn.AvailableCamera]
     scene_id: str | None = None
+    # Session seed for the driver session; None ⇒ the service picks a random one.
+    random_seed: int | None = None
 
 
 @dataclass(frozen=True)
@@ -39,6 +41,8 @@ class TrafficSessionConfig:
     start_timestamp_us: int
     force_gt_duration_us: int
     control_timestep_us: int
+    # Session seed for the traffic session; None ⇒ the service picks a random one.
+    random_seed: int | None = None
 
 
 @dataclass(frozen=True)

--- a/src/runtime/alpasim_runtime/services/traffic_service.py
+++ b/src/runtime/alpasim_runtime/services/traffic_service.py
@@ -91,7 +91,11 @@ class TrafficService(ServiceBase[TrafficServiceStub]):
         session_request = TrafficSessionRequest(
             session_uuid=session_info.uuid,
             scene_id=scene_id,
-            random_seed=random.randint(0, 2**32 - 1),
+            random_seed=(
+                cfg.random_seed
+                if cfg.random_seed is not None
+                else random.randint(0, 2**32 - 1)
+            ),
             logged_object_trajectories=logged_object_trajectories,
             handover_time_us=handover_time_us,
         )

--- a/src/runtime/alpasim_runtime/unbound_rollout.py
+++ b/src/runtime/alpasim_runtime/unbound_rollout.py
@@ -211,6 +211,10 @@ class UnboundRollout:
 
     render_bundling: RenderBundling = RenderBundling.NONE
 
+    # Session seed shared by this rollout's driver and traffic sessions;
+    # 0 ⇒ each service picks a random one (today's behaviour).
+    session_seed: int = 0
+
     @staticmethod
     def create(
         simulation_config: SimulationConfig,
@@ -221,6 +225,7 @@ class UnboundRollout:
         renderer_service: RendererService,
         session_uuid: str | None = None,
         start_time_offset_us: int = 0,
+        session_seed: int = 0,
     ) -> UnboundRollout:
         """Create UnboundRollout from SceneDataSource.
 
@@ -318,6 +323,7 @@ class UnboundRollout:
 
         return UnboundRollout(
             rollout_uuid=session_uuid or str(uuid.uuid1()),
+            session_seed=session_seed,
             scene_id=scene_id,
             gt_ego_trajectory=gt_ego_trajectory,
             traffic_objs=traffic_objects,

--- a/src/runtime/alpasim_runtime/worker/ipc.py
+++ b/src/runtime/alpasim_runtime/worker/ipc.py
@@ -60,6 +60,8 @@ class PendingRolloutJob:
     session_uuid: str = ""
     # µs to skip from the recording start. See RolloutSpec in runtime.proto.
     start_time_offset_us: int = 0
+    # Session seed for this rollout; 0 ⇒ services pick a random one. See RolloutSpec.
+    session_seed: int = 0
     # Number of failed attempts before this pending attempt.
     retry_attempt: int = 0
     # Creation time (monotonic clock); basis for scheduler-wait telemetry.
@@ -87,6 +89,8 @@ class AssignedRolloutJob:
     session_uuid: str = ""
     # µs to skip from the recording start. See RolloutSpec in runtime.proto.
     start_time_offset_us: int = 0
+    # Session seed for this rollout; 0 ⇒ services pick a random one. See RolloutSpec.
+    session_seed: int = 0
 
 
 @dataclass

--- a/src/runtime/alpasim_runtime/worker/main.py
+++ b/src/runtime/alpasim_runtime/worker/main.py
@@ -136,6 +136,7 @@ async def run_single_rollout(
                 rollouts_dir=rollouts_dir,
                 session_uuid=job.session_uuid,
                 start_time_offset_us=job.start_time_offset_us,
+                session_seed=job.session_seed,
                 renderer_service=renderer_service,
             ),
         )

--- a/src/runtime/tests/services/test_driver_service_sessions.py
+++ b/src/runtime/tests/services/test_driver_service_sessions.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA Corporation
+
+from __future__ import annotations
+
+import pytest
+from alpasim_runtime.services.driver_service import DriverService
+from alpasim_runtime.services.service_base import SessionInfo
+from alpasim_runtime.services.session_configs import DriverSessionConfig
+
+
+class RecordingBroadcaster:
+    def __init__(self) -> None:
+        self.entries = []
+
+    async def broadcast(self, entry) -> None:
+        self.entries.append(entry)
+
+
+@pytest.mark.asyncio
+async def test_driver_session_request_uses_configured_seed() -> None:
+    broadcaster = RecordingBroadcaster()
+    service = DriverService(address="localhost:0", skip=True)
+
+    await service._initialize_session(
+        SessionInfo(
+            uuid="session-seeded",
+            broadcaster=broadcaster,
+            session_config=DriverSessionConfig(
+                sensorsim_cameras=[],
+                scene_id="clipgt-01d503d4-449b-46fc-8d78-9085e70d3554",
+                random_seed=777,
+            ),
+        )
+    )
+
+    assert len(broadcaster.entries) == 1
+    request = broadcaster.entries[0].driver_session_request
+    assert request.random_seed == 777
+
+
+@pytest.mark.asyncio
+async def test_driver_session_request_randomizes_seed_when_unset() -> None:
+    broadcaster = RecordingBroadcaster()
+    service = DriverService(address="localhost:0", skip=True)
+
+    await service._initialize_session(
+        SessionInfo(
+            uuid="session-random",
+            broadcaster=broadcaster,
+            session_config=DriverSessionConfig(sensorsim_cameras=[]),
+        )
+    )
+
+    assert len(broadcaster.entries) == 1
+    request = broadcaster.entries[0].driver_session_request
+    assert 0 <= request.random_seed < 2**32

--- a/src/runtime/tests/services/test_traffic_service.py
+++ b/src/runtime/tests/services/test_traffic_service.py
@@ -43,3 +43,30 @@ async def test_traffic_session_request_uses_scene_id() -> None:
     assert len(broadcaster.entries) == 1
     request = broadcaster.entries[0].traffic_session_request
     assert request.scene_id == "clipgt-01d503d4-449b-46fc-8d78-9085e70d3554"
+
+
+@pytest.mark.asyncio
+async def test_traffic_session_request_uses_configured_seed() -> None:
+    broadcaster = RecordingBroadcaster()
+    service = TrafficService(address="localhost:0", skip=True)
+
+    await service._initialize_session(
+        SessionInfo(
+            uuid="session-seeded",
+            broadcaster=broadcaster,
+            session_config=TrafficSessionConfig(
+                traffic_objs={},
+                scene_id="clipgt-01d503d4-449b-46fc-8d78-9085e70d3554",
+                ego_aabb=AABB(x=4.5, y=2.0, z=1.7),
+                gt_ego_aabb_trajectory=Trajectory.create_empty(),
+                start_timestamp_us=0,
+                force_gt_duration_us=100_000,
+                control_timestep_us=100_000,
+                random_seed=1234,
+            ),
+        )
+    )
+
+    assert len(broadcaster.entries) == 1
+    request = broadcaster.entries[0].traffic_session_request
+    assert request.random_seed == 1234

--- a/src/runtime/tests/test_daemon_request_plumbing.py
+++ b/src/runtime/tests/test_daemon_request_plumbing.py
@@ -96,3 +96,27 @@ def test_adapter_propagates_start_time_offset_to_every_job() -> None:
 
     jobs = build_pending_jobs_from_request(req, "req-1", lambda _scene_id: True)
     assert [job.start_time_offset_us for job in jobs] == [1_500_000, 1_500_000]
+
+
+def test_adapter_derives_per_rollout_session_seeds_from_spec_seed() -> None:
+    req = runtime_pb2.SimulationRequest(
+        rollout_specs=[
+            runtime_pb2.RolloutSpec(
+                scenario_id="clipgt-a", nr_rollouts=3, random_seed=100
+            )
+        ]
+    )
+
+    jobs = build_pending_jobs_from_request(req, "req-1", lambda _scene_id: True)
+    assert [job.session_seed for job in jobs] == [100, 101, 102]
+
+
+def test_adapter_leaves_session_seed_unset_when_spec_has_no_seed() -> None:
+    req = runtime_pb2.SimulationRequest(
+        rollout_specs=[
+            runtime_pb2.RolloutSpec(scenario_id="clipgt-a", nr_rollouts=2)
+        ]
+    )
+
+    jobs = build_pending_jobs_from_request(req, "req-1", lambda _scene_id: True)
+    assert [job.session_seed for job in jobs] == [0, 0]


### PR DESCRIPTION
Follow-up to #128.

`force_determinism` and the `inference_seed` hookup (`session.seed + session.inference_count`) have shipped since that discussion, so per-inference seeds already derive deterministically from the session seed. What was still missing is choosing or recovering the session seed itself: `driver_service.py` and `traffic_service.py` draw it from `random.randint` at session creation, and `RolloutSpec` has no seed field, so no rollout can be re-run.

This adds `fixed64 random_seed = 5;` to `RolloutSpec`, with `0` (default) meaning the runtime picks a random seed per session, the same convention `start_time_offset_us` already uses in that message. Rollout *k* of a spec gets `random_seed + k` as its session seed, mirroring the additive derivation `inference_seed` already uses, so a single rollout is reproducible on its own. Existing callers see no change.

The value travels the exact path `start_time_offset_us` takes: `RolloutSpec` to `PendingRolloutJob` to `AssignedRolloutJob` to `UnboundRollout` to the session configs to the session request. Both services fall back to `random.randint` when it's unset.

Out of scope on purpose: making trafficsim consume its seed. Today `request.random_seed` only appears in a log line (`trafficsim/grpc/servicer.py:213`), and how much reproducibility is realistically achievable there needs its own discussion. The video-model renderer path also has its own sampling, so this is about re-running a rollout and getting the same policy behaviour, not bit-exact replay, which matches the NuRec caveat in #128 anyway.

Tests: seed derivation and the unset default in `test_daemon_request_plumbing.py`; both services honouring a configured seed, plus the random fallback, in `tests/services/`. Targeted suites pass 30/30, and the full runtime suite is unaffected beyond failures that reproduce identically without this change.
