### PR TITLE
ci: avoid LFS downloads while replaying GitHub changes to GitLab

### DIFF
--- a/.github/workflows/sync-to-gitlab.yml
+++ b/.github/workflows/sync-to-gitlab.yml
@@ -70,6 +70,7 @@ jobs:
         env:
           BEFORE_SHA: ${{ github.event.before || '' }}
           AFTER_SHA: ${{ github.sha }}
+          GIT_LFS_SKIP_SMUDGE: "1"
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
The sync job checks out the GitLab target branch before replaying changes. That checkout can trigger Git LFS smudging for files unrelated to the changes being synchronized, causing the job to fail when an LFS object is unavailable to the runner.

Disable LFS smudging for the replay step so the sync operates on Git pointers and only transfers the Git changes it is responsible for.