### PR TITLE
Fix MTGS scene mapping and stale actor rendering

### DIFF
--- a/plugins/mtgs/server/engine/gaussian_model/rigid_object.py
+++ b/plugins/mtgs/server/engine/gaussian_model/rigid_object.py
@@ -189,10 +189,10 @@ class RigidPortableSubModel(VanillaPortableGaussianModel):
         if quat is not None and trans is not None:
             assert quat.shape == (4,) and trans.shape == (3,)
             return quat.float(), trans.float(), timestamp
-        if not self.log_replay:
-            return None
         if self.static_in_log:
             return self.log_quats, self.log_trans, timestamp
+        if not self.log_replay:
+            return None
         return self._get_log_pose_from_timestamp(timestamp)
 
     def get_global_gaussians(self, quat=None, trans=None, timestamp=None, **kwargs):

--- a/plugins/mtgs/server/engine/gaussian_model/rigid_object.py
+++ b/plugins/mtgs/server/engine/gaussian_model/rigid_object.py
@@ -115,13 +115,29 @@ class RigidPortableSubModel(VanillaPortableGaussianModel):
 
     def _get_log_pose_from_timestamp(self, timestamp):
         self.log_timestamps = self.log_timestamps.to(self.device)
-        relative_timestamp = timestamp - self.log_start_time
+        relative_timestamp = self._to_relative_log_timestamp(timestamp)
+        relative_timestamp = torch.as_tensor(
+            relative_timestamp,
+            dtype=self.log_timestamps.dtype,
+            device=self.device,
+        )
 
+        # Clamp instead of relying on argmin over an all-inf tensor. The old
+        # implementation happened to select frame zero before the log started
+        # and could interpolate between the last and first frames after the log
+        # ended, producing frozen or distorted actors.
+        relative_timestamp = relative_timestamp.clamp(
+            min=self.log_timestamps.min(),
+            max=self.log_timestamps.max(),
+        )
         diffs = relative_timestamp - self.log_timestamps
         prev_frame = torch.argmin(torch.where(diffs >= 0, diffs, float("inf")))
         next_frame = torch.argmin(torch.where(diffs <= 0, -diffs, float("inf")))
 
-        if next_frame == prev_frame:
+        if (
+            next_frame == prev_frame
+            or self.log_timestamps[next_frame] == relative_timestamp
+        ):
             return self.log_quats[next_frame], self.log_trans[next_frame], timestamp
 
         t = (relative_timestamp - self.log_timestamps[prev_frame]) / (
@@ -137,20 +153,57 @@ class RigidPortableSubModel(VanillaPortableGaussianModel):
 
         return quat_interp, trans_interp, timestamp
 
+    def _to_relative_log_timestamp(self, timestamp):
+        """Convert either an absolute or scene-relative timestamp to log time.
+
+        WorldEngine supplies epoch-based microseconds, while AlpaSim render
+        requests use microseconds from the beginning of the simulation. Choose
+        the domain whose valid interval is closest to the supplied timestamp.
+        This also classifies slightly out-of-range timestamps correctly before
+        ``_get_log_pose_from_timestamp`` clamps them to the available log.
+        """
+        timestamp = float(timestamp)
+        relative_start = float(self.log_timestamps.min().item())
+        relative_end = float(self.log_timestamps.max().item())
+        absolute_start = float(self.log_start_time) + relative_start
+        absolute_end = float(self.log_start_time) + relative_end
+
+        def distance_to_interval(value, start, end):
+            if value < start:
+                return start - value
+            if value > end:
+                return value - end
+            return 0.0
+
+        relative_distance = distance_to_interval(
+            timestamp, relative_start, relative_end
+        )
+        absolute_distance = distance_to_interval(
+            timestamp, absolute_start, absolute_end
+        )
+        if absolute_distance < relative_distance:
+            return timestamp - float(self.log_start_time)
+        return timestamp
+
     def _decide_global_pose(self, quat=None, trans=None, timestamp=None):
-        if self.static_in_log:
-            return self.log_quats, self.log_trans, timestamp
         if quat is not None and trans is not None:
             assert quat.shape == (4,) and trans.shape == (3,)
             return quat.float(), trans.float(), timestamp
+        if not self.log_replay:
+            return None
+        if self.static_in_log:
+            return self.log_quats, self.log_trans, timestamp
         return self._get_log_pose_from_timestamp(timestamp)
 
     def get_global_gaussians(self, quat=None, trans=None, timestamp=None, **kwargs):
-        quat, trans, timestamp = self._decide_global_pose(
+        global_pose = self._decide_global_pose(
             quat=quat,
             trans=trans,
             timestamp=timestamp,
         )
+        if global_pose is None:
+            return None
+        quat, trans, timestamp = global_pose
 
         return {
             "means": self.get_means(global_trans=trans, global_quat=quat),

--- a/plugins/mtgs/server/engine/mtgs.py
+++ b/plugins/mtgs/server/engine/mtgs.py
@@ -108,6 +108,7 @@ class MTGS(BaseRenderer):
         # agent membership (e.g. warmup with empty traffic vs first real frame
         # with full traffic) correctly miss the cache.
         self._world_cache_key = None
+        self._active_asset_tokens = ()
         self.sensor_mapping = {}
 
     def _init_gaussian_models(self):
@@ -330,6 +331,7 @@ class MTGS(BaseRenderer):
             "quats": [],
             "opacities": [],
         }
+        active_asset_tokens = []
         for asset_token in self.node_types.keys():
             gaussian_model = self.gaussian_models[self.submodel_names[asset_token]]
             if asset_token in agent_states.keys():
@@ -346,10 +348,13 @@ class MTGS(BaseRenderer):
                     timestamp=timestamp,
                 )
                 if gs is None:
-                    logger.warning(
-                        f"get_global_gaussians returned None for {asset_token}"
+                    logger.debug(
+                        "Skipping inactive asset actor %s at timestamp %s",
+                        asset_token,
+                        timestamp,
                     )
                     continue
+                active_asset_tokens.append(asset_token)
                 for k in gs_dict.keys():
                     gs_dict[k].append(gs[k].to(self.device))
             except Exception as e:
@@ -375,6 +380,7 @@ class MTGS(BaseRenderer):
                 new_collected_gaussians[key] = torch.cat(value, dim=0)
             self.collected_gaussians = new_collected_gaussians
             self.timestamp = timestamp
+            self._active_asset_tokens = tuple(active_asset_tokens)
             self._world_cache_key = cache_key
         except Exception as e:
             logger.error(f"Failed to merge gaussians: {e}", exc_info=True)
@@ -382,7 +388,7 @@ class MTGS(BaseRenderer):
 
     def update_gaussian_rgbs(self, camera_to_worlds):
         rgb_list = []
-        for asset_token in self.node_types.keys():
+        for asset_token in self._active_asset_tokens:
             gaussian_model = self.gaussian_models[self.submodel_names[asset_token]]
             rgbs = []
             for i in range(camera_to_worlds.shape[0]):

--- a/plugins/mtgs/server/main.py
+++ b/plugins/mtgs/server/main.py
@@ -78,9 +78,14 @@ def _build_token_to_asset_folder(configs_dir: Path) -> dict:
             cfg = yaml.load(yaml_file.read_text(), Loader=_SafeLoader)
             if not isinstance(cfg, dict):
                 continue
-            road_block_name = cfg.get("road_block_name", "")
+            central_log = cfg.get("central_log", "")
             central_tokens = cfg.get("central_tokens", [])
-            if not road_block_name or not central_tokens:
+            if not central_tokens:
+                continue
+            road_block_name = cfg.get("road_block_name", "")
+            if not road_block_name and central_log:
+                road_block_name = f"{central_log}-{central_tokens[0]}"
+            if not road_block_name:
                 continue
             for token in central_tokens:
                 mapping[str(token)] = road_block_name

--- a/plugins/mtgs/server/main.py
+++ b/plugins/mtgs/server/main.py
@@ -13,7 +13,7 @@ import argparse
 import logging
 from concurrent import futures
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Optional
 
 from alpasim_grpc.v0.sensorsim_pb2_grpc import add_SensorsimServiceServicer_to_server
 from alpasim_mtgs.server.servicer import MTGSSensorsimService
@@ -42,7 +42,55 @@ logger = logging.getLogger(__name__)
 DATASET_NAME_MAPPING = {
     "nuplan_test": "navtest",
     "nuplan_mini": "navtest",
+    "nuplan_private": "private",
 }
+
+
+def _build_token_to_asset_folder(configs_dir: Path) -> dict:
+    """Read MTGS config YAMLs to build a central_token → road_block_name mapping.
+
+    Each YAML lists all central_tokens sharing one rendered asset folder
+    (road_block_name = central_log + '-' + central_tokens[0]).  This mapping
+    lets the MTGS server resolve any token to its shared asset folder at
+    runtime, regardless of the trajdata cache state.
+    """
+    import yaml
+
+    class _SafeLoader(yaml.SafeLoader):
+        pass
+
+    _SafeLoader.add_multi_constructor(
+        "tag:yaml.org,2002:python/object",
+        lambda loader, tag, node: loader.construct_mapping(node, deep=True),
+    )
+    _SafeLoader.add_multi_constructor(
+        "tag:yaml.org,2002:python/tuple",
+        lambda loader, tag, node: loader.construct_sequence(node, deep=True),
+    )
+
+    mapping: dict = {}
+    if not configs_dir.exists():
+        logger.warning("MTGS configs dir not found: %s", configs_dir)
+        return mapping
+
+    for yaml_file in configs_dir.glob("*.yaml"):
+        try:
+            cfg = yaml.load(yaml_file.read_text(), Loader=_SafeLoader)
+            if not isinstance(cfg, dict):
+                continue
+            road_block_name = cfg.get("road_block_name", "")
+            central_tokens = cfg.get("central_tokens", [])
+            if not road_block_name or not central_tokens:
+                continue
+            for token in central_tokens:
+                mapping[str(token)] = road_block_name
+        except Exception as exc:
+            logger.warning("Failed to load %s: %s", yaml_file.name, exc)
+
+    logger.info(
+        "Built asset-folder mapping for %d tokens from %s", len(mapping), configs_dir
+    )
+    return mapping
 
 
 def parse_args(arg_list: list[str] | None = None) -> argparse.Namespace:
@@ -98,6 +146,17 @@ def create_get_scene_function(
     mtgs_asset_base_path = str(Path(asset_base_path_config) / mapped_name / "assets")
     logger.info(f"MTGS asset path: {mtgs_asset_base_path}")
 
+    configs_dir = Path(asset_base_path_config) / mapped_name / "configs"
+    token_to_asset_folder = _build_token_to_asset_folder(configs_dir)
+
+    def _asset_folder_resolver(scene) -> str:
+        token = scene.name.rsplit("-", 1)[-1]
+        return token_to_asset_folder.get(str(token), scene.name)
+
+    asset_folder_resolver: Optional[Callable] = (
+        _asset_folder_resolver if token_to_asset_folder else None
+    )
+
     params = trajdata_provider_config_to_params(trajdata_config)
     logger.info("Creating UnifiedDataset from config")
     dataset = UnifiedDataset(**params)
@@ -127,6 +186,7 @@ def create_get_scene_function(
             vector_map_params=dataset.vector_map_params,
             smooth_trajectories=user_config.smooth_trajectories,
             asset_base_path=mtgs_asset_base_path,
+            asset_folder_resolver=asset_folder_resolver,
         )
 
         scene_cache[scene_id] = data_source

--- a/plugins/mtgs/tests/test_mtgs_plugin.py
+++ b/plugins/mtgs/tests/test_mtgs_plugin.py
@@ -138,6 +138,21 @@ def test_mtgs_scene_loader_requires_asset_base_path(monkeypatch):
         mtgs_main.create_get_scene_function(_mtgs_user_config())
 
 
+def test_build_token_to_asset_folder_infers_road_block_name(tmp_path):
+    from alpasim_mtgs.server import main as mtgs_main
+
+    (tmp_path / "scene.yaml").write_text(
+        "central_log: log-a\n" "central_tokens:\n" "  - token-1\n" "  - token-2\n"
+    )
+
+    mapping = mtgs_main._build_token_to_asset_folder(tmp_path)
+
+    assert mapping == {
+        "token-1": "log-a-token-1",
+        "token-2": "log-a-token-1",
+    }
+
+
 def test_mtgs_scene_loader_uses_public_trajdata_dataset_api(monkeypatch):
     from alpasim_mtgs.server import main as mtgs_main
 

--- a/plugins/mtgs/tests/test_mtgs_plugin.py
+++ b/plugins/mtgs/tests/test_mtgs_plugin.py
@@ -171,6 +171,21 @@ def test_rigid_dynamic_actor_without_pose_requires_log_replay():
     assert model._decide_global_pose(timestamp=0) is not None
 
 
+def test_rigid_static_actor_uses_log_pose_without_log_replay():
+    import torch
+
+    model = _rigid_model_for_log_pose_tests(log_replay=False)
+    model.static_in_log = True
+    model.log_quats = torch.nn.Parameter(torch.tensor([1.0, 0.0, 0.0, 0.0]))
+    model.log_trans = torch.nn.Parameter(torch.tensor([0.0, 0.0, 0.0]))
+
+    quat, trans, timestamp = model._decide_global_pose(timestamp=0)
+
+    torch.testing.assert_close(quat, model.log_quats)
+    torch.testing.assert_close(trans, model.log_trans)
+    assert timestamp == 0
+
+
 def test_rigid_explicit_pose_overrides_static_log_pose():
     import torch
 
@@ -181,7 +196,6 @@ def test_rigid_explicit_pose_overrides_static_log_pose():
     requested_quat = torch.tensor([1.0, 0.0, 0.0, 0.0])
     requested_trans = torch.tensor([5.0, 6.0, 7.0])
 
-    assert model._decide_global_pose(timestamp=0) is None
     quat, trans, _ = model._decide_global_pose(
         quat=requested_quat,
         trans=requested_trans,

--- a/plugins/mtgs/tests/test_mtgs_plugin.py
+++ b/plugins/mtgs/tests/test_mtgs_plugin.py
@@ -96,6 +96,147 @@ def test_mtgs_engine_importable():
         pytest.skip(f"Server dependencies not installed: {e}")
 
 
+def _rigid_model_for_log_pose_tests(*, log_replay: bool = True):
+    import torch
+    from alpasim_mtgs.server.engine.gaussian_model.rigid_object import (
+        RigidPortableSubModel,
+    )
+
+    model = RigidPortableSubModel.__new__(RigidPortableSubModel)
+    torch.nn.Module.__init__(model)
+    model.log_replay = log_replay
+    model.static_in_log = False
+    model.gauss_params = {"means": torch.zeros(1)}
+    model.log_start_time = 1_621_970_015_499_931
+    model.log_timestamps = torch.tensor([0.0, 500_000.0, 1_000_000.0])
+    model.log_quats = torch.nn.Parameter(
+        torch.tensor(
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0, 0.0],
+            ]
+        )
+    )
+    model.log_trans = torch.nn.Parameter(
+        torch.tensor(
+            [
+                [0.0, 0.0, 0.0],
+                [5.0, 0.0, 0.0],
+                [10.0, 0.0, 0.0],
+            ]
+        )
+    )
+    return model
+
+
+def test_rigid_log_pose_accepts_relative_and_absolute_timestamps():
+    import torch
+
+    model = _rigid_model_for_log_pose_tests()
+    relative_timestamp = 250_000
+    absolute_timestamp = model.log_start_time + relative_timestamp
+
+    _, relative_trans, _ = model._get_log_pose_from_timestamp(relative_timestamp)
+    _, absolute_trans, _ = model._get_log_pose_from_timestamp(absolute_timestamp)
+
+    torch.testing.assert_close(relative_trans, torch.tensor([2.5, 0.0, 0.0]))
+    torch.testing.assert_close(absolute_trans, relative_trans)
+
+
+@pytest.mark.parametrize(
+    ("timestamp", "expected_x"),
+    [
+        (-100_000, 0.0),
+        (1_500_000, 10.0),
+        (1_621_970_015_399_931, 0.0),
+        (1_621_970_016_999_931, 10.0),
+    ],
+)
+def test_rigid_log_pose_clamps_out_of_range_timestamps(timestamp, expected_x):
+    model = _rigid_model_for_log_pose_tests()
+
+    _, trans, _ = model._get_log_pose_from_timestamp(timestamp)
+
+    assert trans[0].item() == expected_x
+
+
+def test_rigid_dynamic_actor_without_pose_requires_log_replay():
+    model = _rigid_model_for_log_pose_tests(log_replay=False)
+
+    assert model._decide_global_pose(timestamp=0) is None
+    assert model.get_global_gaussians(timestamp=0) is None
+
+    model.log_replay = True
+    assert model._decide_global_pose(timestamp=0) is not None
+
+
+def test_rigid_explicit_pose_overrides_static_log_pose():
+    import torch
+
+    model = _rigid_model_for_log_pose_tests(log_replay=False)
+    model.static_in_log = True
+    model.log_quats = torch.nn.Parameter(torch.tensor([1.0, 0.0, 0.0, 0.0]))
+    model.log_trans = torch.nn.Parameter(torch.tensor([0.0, 0.0, 0.0]))
+    requested_quat = torch.tensor([1.0, 0.0, 0.0, 0.0])
+    requested_trans = torch.tensor([5.0, 6.0, 7.0])
+
+    assert model._decide_global_pose(timestamp=0) is None
+    quat, trans, _ = model._decide_global_pose(
+        quat=requested_quat,
+        trans=requested_trans,
+        timestamp=0,
+    )
+
+    torch.testing.assert_close(quat, requested_quat)
+    torch.testing.assert_close(trans, requested_trans)
+
+
+def test_mtgs_rgb_collection_matches_active_geometry():
+    import torch
+    from alpasim_mtgs.server.engine.mtgs import MTGS
+
+    class ActiveModel:
+        def get_global_gaussians(self, **_kwargs):
+            return {
+                "means": torch.zeros((1, 3)),
+                "scales": torch.ones((1, 3)),
+                "quats": torch.tensor([[1.0, 0.0, 0.0, 0.0]]),
+                "opacities": torch.ones(1),
+            }
+
+        def get_gaussian_rgbs(self, **_kwargs):
+            return torch.ones((1, 3))
+
+    class InactiveModel:
+        def get_global_gaussians(self, **_kwargs):
+            return None
+
+        def get_gaussian_rgbs(self, **_kwargs):
+            raise AssertionError("inactive model must not contribute RGB features")
+
+    renderer = MTGS.__new__(MTGS)
+    renderer.device = torch.device("cpu")
+    renderer.node_types = {"background": "background", "inactive": "na"}
+    renderer.submodel_names = {
+        "background": "background",
+        "inactive": "inactive",
+    }
+    renderer.gaussian_models = {
+        "background": ActiveModel(),
+        "inactive": InactiveModel(),
+    }
+    renderer._world_cache_key = None
+    renderer._active_asset_tokens = ()
+
+    renderer.update_world(timestamp=0, agent_states={})
+    renderer.update_gaussian_rgbs(torch.eye(4).unsqueeze(0))
+
+    assert renderer._active_asset_tokens == ("background",)
+    assert renderer.collected_gaussians["means"].shape[0] == 1
+    assert renderer.collected_gaussians["rgbs"].shape[1] == 1
+
+
 def test_mtgs_asset_manager_allows_missing_road_height_map(tmp_path, monkeypatch):
     import torch
     from alpasim_mtgs.server.engine.mtgs import MTGSAssetManager

--- a/src/runtime/alpasim_runtime/scene_loader.py
+++ b/src/runtime/alpasim_runtime/scene_loader.py
@@ -120,26 +120,16 @@ def _resolve_nuplan_extra_params(dataset_name: str, extra_params: dict) -> dict:
     for yaml_file in yaml_files:
         try:
             cfg = yaml.load(yaml_file.read_text(), Loader=_SafeLoader)
-            central_log = (
-                cfg.get("central_log", "")
-                if isinstance(cfg, dict)
-                else getattr(cfg, "central_log", "")
-            )
-            central_tokens = (
-                cfg.get("central_tokens", [])
-                if isinstance(cfg, dict)
-                else getattr(cfg, "central_tokens", [])
-            )
+            central_log = cfg.get("central_log", "")
+            central_tokens = cfg.get("central_tokens", [])
             if not central_log or not central_tokens:
                 logger.warning(
                     "%s missing central_log or central_tokens, skipping", yaml_file.name
                 )
                 continue
             road_block_name = (
-                cfg.get("road_block_name", "")
-                if isinstance(cfg, dict)
-                else getattr(cfg, "road_block_name", "")
-            ) or f"{central_log}-{central_tokens[0]}"
+                cfg.get("road_block_name", "") or f"{central_log}-{central_tokens[0]}"
+            )
             for token in central_tokens:
                 configs_by_log[central_log].append(
                     {

--- a/src/runtime/alpasim_runtime/scene_loader.py
+++ b/src/runtime/alpasim_runtime/scene_loader.py
@@ -135,9 +135,18 @@ def _resolve_nuplan_extra_params(dataset_name: str, extra_params: dict) -> dict:
                     "%s missing central_log or central_tokens, skipping", yaml_file.name
                 )
                 continue
+            road_block_name = (
+                cfg.get("road_block_name", "")
+                if isinstance(cfg, dict)
+                else getattr(cfg, "road_block_name", "")
+            ) or f"{central_log}-{central_tokens[0]}"
             for token in central_tokens:
                 configs_by_log[central_log].append(
-                    {"central_token": token, "logfile": central_log}
+                    {
+                        "central_token": token,
+                        "logfile": central_log,
+                        "asset_folder": road_block_name,
+                    }
                 )
         except Exception as exc:
             logger.warning("Failed to load %s: %s", yaml_file.name, exc)

--- a/src/trajdata/src/trajdata/dataset_specific/nuplan/nuplan_utils.py
+++ b/src/trajdata/src/trajdata/dataset_specific/nuplan/nuplan_utils.py
@@ -225,17 +225,18 @@ class NuPlanObject:
             # Create scene name using the central token format.
             scene_name = f"{logfile_name}-{central_token_hex}"
 
-            scenes.append(
-                {
-                    "name": scene_name,
-                    "location": _NUPLAN_SQL_MAP_FRIENDLY_NAMES_DICT.get(
-                        location, location
-                    ),
-                    "num_timesteps": num_timesteps,
-                    "start_idx": start_idx,
-                    "end_idx": end_idx,
-                }
-            )
+            scene_dict: Dict[str, Any] = {
+                "name": scene_name,
+                "location": _NUPLAN_SQL_MAP_FRIENDLY_NAMES_DICT.get(
+                    location, location
+                ),
+                "num_timesteps": num_timesteps,
+                "start_idx": start_idx,
+                "end_idx": end_idx,
+            }
+            if "asset_folder" in config:
+                scene_dict["asset_folder"] = config["asset_folder"]
+            scenes.append(scene_dict)
 
             self.close_db()
 


### PR DESCRIPTION
## Summary

- Resolve NuPlan scene tokens to their shared MTGS asset folders, including configs without an explicit road_block_name.
- Propagate the asset folder through newly generated trajdata caches.
- Prevent inactive or out-of-range MTGS actors from leaving stale Gaussian data in later frames.
- Add regression coverage for scene mapping, timestamp handling, and active-actor cache updates.

## Root cause

Multiple NuPlan scene tokens can share one MTGS road-block asset folder, but the renderer previously fell back to the unique scene token when cache metadata was missing. Separately, actors outside their valid replay interval could reuse stale render state, producing visible ghosting.

## Impact

The affected NuPlan scene now resolves the correct background asset and no longer shows stale actor trails during rollout.

## Validation

- MTGS plugin tests: 20 passed.
- Pre-commit checks passed.
- GPU smoke test completed for 2021.05.25.14.16.10_veh-35_03373_03550-80a4b14aef3f5a52.
- Rendered output was inspected manually and no visible ghosting remained.

This is a draft so the target repository can run its own local GPU smoke test before review.

@WCJ-BERT