### PR TITLE
Document SimScale/NAVSIM sample submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ AlpaSim currently supports the following driver policies:
 - [Transfuser](https://github.com/autonomousvision/lead?tab=readme-ov-file#beyond-carla-cross-benchmark-deployment)
   \- Latent TransFuser v6 ([LTFv6](<(https://huggingface.co/ln2697/tfv6_navsim)>)) policy developed
   for [NAVSIM](https://github.com/autonomousvision/navsim) (provisional)
+- [SimScale](https://github.com/OpenDriveLab/SimScale) - a series of [NAVSIM](https://github.com/autonomousvision/navsim)-style policies co-trained on simulation and real-world data; see the [adaptation guide](e2e_challenge/NAVSIM_MODEL_ADAPTATION.md).
 
 Stay tuned for additional model support. [Contributions](#contributing) from the community are
 appreciated.
@@ -163,6 +164,7 @@ Watson
 - Physics: Riccardo de Lutio
 - Trafficsim: Maximilian Igl, Boris Ivanovic
 - MTGS integration: Caojun Wang
+- SimScale/NAVSIM integration: Haochen Tian
 
 **Senior Mgmt:** Sanja Fidler, Zan Gojcic, Boris Ivanovic, Marco Pavone
 

--- a/e2e_challenge/README.md
+++ b/e2e_challenge/README.md
@@ -13,6 +13,7 @@ and wait for approval.
 
 - [Starter kit](starter_kit/README.md): build and locally test a minimal driver container
 - [VAVAM sample submission](sample_submission_vavam/README.md): build and locally test a VAVAM-backed driver container
+- [SimScale/NAVSIM sample submissions](NAVSIM_MODEL_ADAPTATION.md): build and locally test SimScale/NAVSIM-style driver containers, including LTF, DiffusionDrive, and GTRS.
 - [Challenge CLI](competitor_cli/README.md): authenticate, log in to ECR, submit images, check status, view the leaderboard
 
 ## Tracks


### PR DESCRIPTION
## Summary

- add SimScale to the supported driving policies
- link the SimScale/NAVSIM adaptation guide from the E2E challenge documentation
- credit the SimScale/NAVSIM integration work

## Testing

- `git diff --check`
- Documentation-only change; runtime tests were not required