### PR TITLE
runtime: make route generators plugin-selectable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,8 +71,14 @@ jobs:
           cd "src/${{ matrix.service }}"
           uv sync --all-extras
 
+          plugin_test_args=()
+          if [[ "${{ matrix.service }}" == "runtime" ]]; then
+            # Exercise route-plugin discovery even in a runtime-only install.
+            plugin_test_args+=(--with-editable ../plugins)
+          fi
+
           set +e
-          uv run --all-extras pytest -vvs --tb=short
+          uv run --all-extras "${plugin_test_args[@]}" pytest -vvs --tb=short
           status=$?
           set -e
 

--- a/docs/PLUGIN_SYSTEM.md
+++ b/docs/PLUGIN_SYSTEM.md
@@ -40,6 +40,7 @@ The available entry-point groups are:
 | `alpasim.configs` | Hydra config directories (auto-discovered by the wizard) |
 | `alpasim.scorers` | Evaluation metric scorers |
 | `alpasim.tools` | CLI tools |
+| `alpasim.route_generators` | Runtime route generators |
 
 ---
 
@@ -82,6 +83,52 @@ uv run alpasim-info                    # should list your new component
 ```
 
 Model plugins can then be referenced by name in driver configs (e.g. `model_type: transfuser`).
+
+### Adding route generators
+
+A route plugin provides a `RouteGenerator` instance via a
+`from_context(recorded_waypoints_in_local, vector_map, *, route_start_offset_m=0.0)`
+classmethod. The recorded waypoints are an `(N, 3)` array in the local frame.
+`vector_map` is a `VectorMap` or `None` when the scene has no map; plugins that
+require map data must handle that case. The returned generator implements the
+runtime's `generate_route(timestamp_us, pose_local_to_rig)` interface.
+
+For example, this minimal plugin reuses recorded routing:
+
+```python
+# my_routes.py
+from alpasim_runtime.route_generator import RouteGeneratorRecorded
+
+
+class CustomRoutes(RouteGeneratorRecorded):
+    @classmethod
+    def from_context(
+        cls, recorded_waypoints_in_local, vector_map, *, route_start_offset_m=0.0
+    ):
+        return cls(recorded_waypoints_in_local, route_start_offset_m)
+```
+
+Declare dependencies on `alpasim_plugins` and `alpasim-runtime` in your package,
+and register the class:
+
+```toml
+[project.entry-points."alpasim.route_generators"]
+custom = "my_routes:CustomRoutes"
+```
+
+Install the package in the **runtime service's environment**, then select it in
+the runtime user configuration:
+
+```yaml
+simulation_config:
+  route_generator_plugin: custom
+  route_start_offset_m: 0.0
+```
+
+When set, `route_generator_plugin` overrides `route_generator_type`, including
+`NONE`. An unknown name raises `PluginNotFoundError`; it does not fall back to a
+built-in generator. When unset or `null`, the existing `MAP`/`RECORDED`/`NONE`
+selection is used and the runtime does not need `alpasim_plugins` for routing.
 
 ### Adding Hydra configs
 

--- a/src/plugins/alpasim_plugins/__init__.py
+++ b/src/plugins/alpasim_plugins/__init__.py
@@ -9,6 +9,7 @@ from alpasim_plugins.plugins import (
     get_plugin_info,
     models,
     mpc_controllers,
+    route_generators,
     scorers,
     tools,
 )
@@ -19,6 +20,7 @@ __all__ = [
     "get_plugin_info",
     "models",
     "mpc_controllers",
+    "route_generators",
     "scorers",
     "tools",
 ]

--- a/src/plugins/alpasim_plugins/plugins.py
+++ b/src/plugins/alpasim_plugins/plugins.py
@@ -107,6 +107,7 @@ models = PluginRegistry("alpasim.models")
 mpc_controllers = PluginRegistry("alpasim.mpc")
 scorers = PluginRegistry("alpasim.scorers")
 tools = PluginRegistry("alpasim.tools")
+route_generators = PluginRegistry("alpasim.route_generators")
 
 
 def get_plugin_info() -> dict[str, list[str]]:
@@ -121,5 +122,6 @@ def get_plugin_info() -> dict[str, list[str]]:
         "alpasim.scorers",
         "alpasim.tools",
         "alpasim.configs",
+        "alpasim.route_generators",
     ]
     return {group: PluginRegistry(group).get_names() for group in groups}

--- a/src/plugins/tests/test_plugins.py
+++ b/src/plugins/tests/test_plugins.py
@@ -40,6 +40,7 @@ def test_get_plugin_info_returns_all_groups() -> None:
         "alpasim.scorers",
         "alpasim.tools",
         "alpasim.configs",
+        "alpasim.route_generators",
     ]
     for group in expected_groups:
         assert group in info

--- a/src/runtime/alpasim_runtime/config.py
+++ b/src/runtime/alpasim_runtime/config.py
@@ -343,6 +343,7 @@ class SimulationConfig:
 
     route_generator_type: RouteGeneratorType = RouteGeneratorType.MAP
     route_start_offset_m: float = 0.0
+    route_generator_plugin: str | None = None
 
     # Whether to send optional messages to the driver
     send_recording_ground_truth: bool = False

--- a/src/runtime/alpasim_runtime/config.py
+++ b/src/runtime/alpasim_runtime/config.py
@@ -343,6 +343,8 @@ class SimulationConfig:
 
     route_generator_type: RouteGeneratorType = RouteGeneratorType.MAP
     route_start_offset_m: float = 0.0
+    # Optional alpasim.route_generators entry point; overrides route_generator_type,
+    # including NONE. Unset preserves built-in routing without alpasim_plugins.
     route_generator_plugin: str | None = None
 
     # Whether to send optional messages to the driver

--- a/src/runtime/alpasim_runtime/event_loop.py
+++ b/src/runtime/alpasim_runtime/event_loop.py
@@ -174,6 +174,7 @@ class EventBasedRollout:
             vector_map=self.unbound.vector_map,
             route_generator_type=self.unbound.route_generator_type,
             route_start_offset_m=self.unbound.route_start_offset_m,
+            route_generator_plugin=self.unbound.route_generator_plugin,
         )
 
         self._runtime_evaluator = RuntimeEvaluator(

--- a/src/runtime/alpasim_runtime/route_generator.py
+++ b/src/runtime/alpasim_runtime/route_generator.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from typing import final
 
 import numpy as np
+from alpasim_plugins.plugins import route_generators as route_generator_registry
 from alpasim_runtime.config import RouteGeneratorType
 from alpasim_utils.geometry import Polyline, Pose
 from trajdata.maps import VectorMap
@@ -41,6 +42,7 @@ class RouteGenerator(ABC):
         vector_map: VectorMap,
         route_generator_type: RouteGeneratorType,
         route_start_offset_m: float = 0.0,
+        route_generator_plugin: str | None = None,
     ) -> "RouteGenerator | None":
         """
         Factory method to create a RouteGenerator
@@ -52,6 +54,13 @@ class RouteGenerator(ABC):
         Returns:
           A route generator of the specified type, or None if route generation is disabled
         """
+        if route_generator_plugin is not None:
+            plugin_cls = route_generator_registry.get(route_generator_plugin)
+            return plugin_cls.from_context(
+                recorded_waypoints_in_local,
+                vector_map,
+                route_start_offset_m=route_start_offset_m,
+            )
         if route_generator_type == RouteGeneratorType.NONE:
             return None
         elif route_generator_type == RouteGeneratorType.RECORDED:

--- a/src/runtime/alpasim_runtime/route_generator.py
+++ b/src/runtime/alpasim_runtime/route_generator.py
@@ -7,7 +7,6 @@ from abc import ABC, abstractmethod
 from typing import final
 
 import numpy as np
-from alpasim_plugins.plugins import route_generators as route_generator_registry
 from alpasim_runtime.config import RouteGeneratorType
 from alpasim_utils.geometry import Polyline, Pose
 from trajdata.maps import VectorMap
@@ -39,7 +38,7 @@ class RouteGenerator(ABC):
     def create(
         cls,
         recorded_waypoints_in_local: np.ndarray,
-        vector_map: VectorMap,
+        vector_map: VectorMap | None,
         route_generator_type: RouteGeneratorType,
         route_start_offset_m: float = 0.0,
         route_generator_plugin: str | None = None,
@@ -48,14 +47,20 @@ class RouteGenerator(ABC):
         Factory method to create a RouteGenerator
         Args:
           recorded_waypoints_in_local: the waypoints in the local frame. (N, 3) array
-          vector_map: the map data
+          vector_map: the map data, or None when the scene has no map
           route_generator_type: the type of route generator to create
           route_start_offset_m: approximate distance ahead of the ego projection where routes start
+          route_generator_plugin: name of an alpasim.route_generators entry point.
+            When set, overrides route_generator_type (including NONE). The plugin
+            must expose from_context(recorded_waypoints_in_local, vector_map,
+            *, route_start_offset_m=0.0), returning a RouteGenerator instance.
         Returns:
           A route generator of the specified type, or None if route generation is disabled
         """
         if route_generator_plugin is not None:
-            plugin_cls = route_generator_registry.get(route_generator_plugin)
+            from alpasim_plugins import route_generators
+
+            plugin_cls = route_generators.get(route_generator_plugin)
             return plugin_cls.from_context(
                 recorded_waypoints_in_local,
                 vector_map,

--- a/src/runtime/alpasim_runtime/unbound_rollout.py
+++ b/src/runtime/alpasim_runtime/unbound_rollout.py
@@ -196,6 +196,7 @@ class UnboundRollout:
     planner_delay_us: int
     route_generator_type: RouteGeneratorType
     route_start_offset_m: float
+    route_generator_plugin: str | None
     send_recording_ground_truth: bool
     nre_runid: str
     nre_version: str
@@ -365,6 +366,7 @@ class UnboundRollout:
             pose_reporting_interval_us=simulation_config.pose_reporting_interval_us,
             route_generator_type=simulation_config.route_generator_type,
             route_start_offset_m=simulation_config.route_start_offset_m,
+            route_generator_plugin=simulation_config.route_generator_plugin,
             send_recording_ground_truth=simulation_config.send_recording_ground_truth,
             vehicle_config=vehicle,
             vector_map=vector_map,

--- a/src/runtime/tests/test_event_loop.py
+++ b/src/runtime/tests/test_event_loop.py
@@ -112,6 +112,7 @@ def test_initial_ego_context_uses_all_gt_samples_through_first_policy(
         planner_delay_us=0,
         vector_map=None,
         route_generator_type="RECORDED",
+        route_generator_plugin=None,
         route_start_offset_m=0.0,
         rollout_uuid="rollout",
         scene_id="scene",

--- a/src/runtime/tests/test_route_generator.py
+++ b/src/runtime/tests/test_route_generator.py
@@ -2,6 +2,9 @@
 # Copyright (c) 2025-2026 NVIDIA Corporation
 
 import math
+import subprocess
+import sys
+import textwrap
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -12,7 +15,6 @@ from alpasim_runtime.route_generator import (
     RouteGeneratorMap,
     RouteGeneratorRecorded,
 )
-import alpasim_plugins.plugins as plugin_module
 from alpasim_utils.artifact import Artifact
 from alpasim_utils.geometry import Polyline, Pose
 from tests.fixtures import sample_artifact  # noqa: F401
@@ -28,24 +30,100 @@ def _make_pose(vec3: np.ndarray) -> Pose:
     return Pose(np.asarray(vec3, dtype=np.float32), IDENTITY_QUAT)
 
 
-def test_route_generator_plugin_takes_precedence(monkeypatch):
-    class CustomRouteGenerator:
-        @classmethod
-        def from_context(cls, recorded_waypoints_in_local, vector_map, *, route_start_offset_m):
-            return (recorded_waypoints_in_local, vector_map, route_start_offset_m)
+class CustomRouteGenerator(RouteGeneratorRecorded):
+    @classmethod
+    def from_context(
+        cls, recorded_waypoints_in_local, vector_map, *, route_start_offset_m=0.0
+    ):
+        generator = cls(recorded_waypoints_in_local, route_start_offset_m)
+        generator.vector_map = vector_map
+        return generator
 
-    monkeypatch.setattr(plugin_module.route_generators, "get", lambda name: CustomRouteGenerator)
-    waypoints = np.zeros((2, 3), dtype=np.float32)
-    result = RouteGenerator.create(
-        waypoints,
-        None,
-        object(),
-        route_start_offset_m=3.0,
+
+@pytest.fixture
+def route_plugin_package(tmp_path, monkeypatch):
+    plugins = pytest.importorskip("alpasim_plugins")
+    metadata = tmp_path / "test_route_plugin-1.0.dist-info"
+    metadata.mkdir()
+    (metadata / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: test-route-plugin\nVersion: 1.0\n"
+    )
+    (metadata / "entry_points.txt").write_text(
+        f"[alpasim.route_generators]\ncustom = {__name__}:CustomRouteGenerator\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(plugins.route_generators, "_cache", None)
+    return plugins
+
+
+@pytest.mark.parametrize("vector_map", [None, object()])
+def test_route_generator_plugin_takes_precedence(
+    route_plugin_package, rig_waypoints_in_local, vector_map
+):
+    assert "custom" in route_plugin_package.route_generators.get_names()
+    generator = RouteGenerator.create(
+        rig_waypoints_in_local,
+        vector_map,
+        RouteGeneratorType.NONE,
+        route_start_offset_m=40.0,
         route_generator_plugin="custom",
     )
-    assert result[0] is waypoints
-    assert result[1] is None
-    assert result[2] == 3.0
+    assert isinstance(generator, CustomRouteGenerator)
+    assert generator.vector_map is vector_map
+    pose = _make_pose(np.zeros(3))
+    route = generator.generate_route(0, pose)
+    expected = RouteGeneratorRecorded(
+        rig_waypoints_in_local, route_start_offset_m=40.0
+    ).generate_route(0, pose)
+    np.testing.assert_allclose(route.waypoints, expected.waypoints)
+    assert np.linalg.norm(route.waypoints[0]) >= 40.0
+
+
+def test_unknown_route_generator_plugin_does_not_fall_back(
+    route_plugin_package, rig_waypoints_in_local
+):
+    with pytest.raises(
+        route_plugin_package.PluginNotFoundError,
+        match="Plugin 'missing-route-plugin' not found in alpasim.route_generators",
+    ):
+        RouteGenerator.create(
+            rig_waypoints_in_local,
+            None,
+            RouteGeneratorType.RECORDED,
+            route_generator_plugin="missing-route-plugin",
+        )
+
+
+def test_builtin_routes_without_plugin_package():
+    # A fresh interpreter catches eager imports as well as factory-time imports.
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent(
+                """\
+                import sys
+                sys.modules["alpasim_plugins"] = None
+                import numpy as np
+                from alpasim_runtime.config import RouteGeneratorType
+                from alpasim_runtime.route_generator import RouteGenerator, RouteGeneratorRecorded
+                from alpasim_utils.geometry import Pose
+
+                waypoints = np.array([[0., 0., 0.], [100., 0., 0.]])
+                assert RouteGenerator.create(waypoints, None, RouteGeneratorType.NONE) is None
+                generator = RouteGenerator.create(waypoints, None, RouteGeneratorType.RECORDED)
+                assert isinstance(generator, RouteGeneratorRecorded)
+                pose = Pose(np.zeros(3), np.array([0., 0., 0., 1.]))
+                route = generator.generate_route(0, pose)
+                np.testing.assert_allclose(route.waypoints[-1], [80., 0., 0.])
+                """
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 @pytest.fixture

--- a/src/runtime/tests/test_route_generator.py
+++ b/src/runtime/tests/test_route_generator.py
@@ -12,6 +12,7 @@ from alpasim_runtime.route_generator import (
     RouteGeneratorMap,
     RouteGeneratorRecorded,
 )
+import alpasim_plugins.plugins as plugin_module
 from alpasim_utils.artifact import Artifact
 from alpasim_utils.geometry import Polyline, Pose
 from tests.fixtures import sample_artifact  # noqa: F401
@@ -25,6 +26,26 @@ IDENTITY_QUAT = np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32)
 def _make_pose(vec3: np.ndarray) -> Pose:
     """Create a Pose with identity rotation from a 3D position."""
     return Pose(np.asarray(vec3, dtype=np.float32), IDENTITY_QUAT)
+
+
+def test_route_generator_plugin_takes_precedence(monkeypatch):
+    class CustomRouteGenerator:
+        @classmethod
+        def from_context(cls, recorded_waypoints_in_local, vector_map, *, route_start_offset_m):
+            return (recorded_waypoints_in_local, vector_map, route_start_offset_m)
+
+    monkeypatch.setattr(plugin_module.route_generators, "get", lambda name: CustomRouteGenerator)
+    waypoints = np.zeros((2, 3), dtype=np.float32)
+    result = RouteGenerator.create(
+        waypoints,
+        None,
+        object(),
+        route_start_offset_m=3.0,
+        route_generator_plugin="custom",
+    )
+    assert result[0] is waypoints
+    assert result[1] is None
+    assert result[2] == 3.0
 
 
 @pytest.fixture


### PR DESCRIPTION
Related to #150

Thanks for the feedback on #150! Regarding your question about built-in strategies versus plugins, I propose using plugins for project-specific route generators. They can live in separate packages without requiring changes to AlpaSim’s runtime. Generally useful strategies can still be added as built-ins.

This PR adds the extension point using the existing plugin system:

- Register a generator under `alpasim.route_generators`.
- Select it with `route_generator_plugin`, overriding the built-in selection, including `NONE`.
- Leave it unset to keep the existing behavior, without needing the plugin package.

It includes a documentation example and tests; it does not add a new routing strategy. A shared registry for built-in and external generators could be cleaner eventually, but I’ve kept the built-ins unchanged here.

Focused runtime/plugin tests and applicable pre-commit checks passed locally. One map-fixture test and two driver-dependent tests were excluded.

Let me know what you think of this approach!
